### PR TITLE
Inclusion of custom dt overlay into RCU image

### DIFF
--- a/buildconf/bblayers.conf
+++ b/buildconf/bblayers.conf
@@ -6,12 +6,12 @@ BBPATH = "${TOPDIR}"
 BBFILES ?= ""
 
 BBLAYERS ?= " \
+  ${TOPDIR}/../layers/meta-smartrack \
+  \
   ${TOPDIR}/../layers/meta-toradex-nxp \
   ${TOPDIR}/../layers/meta-freescale \
   ${TOPDIR}/../layers/meta-freescale-3rdparty \
-  \
   ${TOPDIR}/../layers/meta-toradex-tegra \
-  \
   ${TOPDIR}/../layers/meta-toradex-bsp-common \
   \
   ${TOPDIR}/../layers/meta-openembedded/meta-oe \
@@ -26,11 +26,9 @@ BBLAYERS ?= " \
   ${TOPDIR}/../layers/meta-toradex-demos \
   ${TOPDIR}/../layers/meta-qt5 \
   \
-  \
   ${TOPDIR}/../layers/meta-toradex-distro \
   ${TOPDIR}/../layers/meta-yocto/meta-poky \
   ${TOPDIR}/../layers/openembedded-core/meta \
   \
-  ${TOPDIR}/../layers/meta-smartrack \
   ${TOPDIR}/../layers/meta-rauc \
 "

--- a/conf/machine/apalis-imx8x.conf
+++ b/conf/machine/apalis-imx8x.conf
@@ -1,0 +1,73 @@
+#@TYPE: Machine
+#@NAME: Toradex Apalis iMX8X
+#@DESCRIPTION: Toradex Apalis iMX8X powered by a i.MX 8X SoC
+#@MAINTAINER: Philippe Schenker <philippe.schenker@toradex.com>
+
+MACHINE_NAME = "Apalis-iMX8X"
+
+# for C0 silicon add mx8qxpc0 to the right of mx8qxp
+SILICON-OVERRIDES ?= "mx8qxpc0:"
+MACHINEOVERRIDES =. "mx8:mx8x:mx8qxp:${SILICON-OVERRIDES}"
+
+IMX_DEFAULT_BSP = "nxp"
+
+require conf/machine/include/imx-base.inc
+# if one wants cortexa35-crypto, set DEFAULTTUNE accordingly
+DEFAULTTUNE_mx8qxp = "aarch64"
+require conf/machine/include/tune-cortexa35.inc
+
+# Don't include kernels in standard images
+RDEPENDS_${KERNEL_PACKAGE_NAME}-base = ""
+
+LOADADDR = ""
+
+# we do not want to have getty running on tty1 as we run
+# auto-serial-console there
+USE_VT = "0"
+
+KERNEL_DEVICETREE = " \
+    freescale/imx8qxp-apalis-eval.dtb \
+"
+
+KERNEL_IMAGETYPE_aarch64 = "Image.gz"
+
+UBOOT_SUFFIX = "bin"
+UBOOT_CONFIG ??= "sd"
+UBOOT_CONFIG[sd] = "apalis-imx8x_defconfig,sdcard"
+
+UBOOT_ENTRYPOINT = "0x80280000"
+UBOOT_RD_LOADADDRESS = "0xA0000000"
+
+BOOT_SPACE = "65536"
+IMX_BOOT_SEEK = "32"
+
+IMAGE_BOOT_FILES_append = " boot.scr-${MACHINE};boot.scr"
+WKS_FILE_DEPENDS_append = " u-boot-default-script"
+PREFERRED_PROVIDER_u-boot-default-script = "u-boot-distro-boot"
+
+PREFERRED_PROVIDER_virtual/kernel = "linux-toradex"
+PREFERRED_PROVIDER_virtual/kernel_preempt-rt = "linux-toradex"
+PREFERRED_PROVIDER_virtual/bootloader = "u-boot-toradex"
+# Currently we use the nxp 2020.04 downstream for mx8 as some features are
+# not yet available in 2020.07.
+PREFERRED_VERSION_u-boot-toradex = "2020.04%"
+
+MACHINE_FIRMWARE_append = " linux-firmware-usb8997"
+MACHINE_FIRMWARE_append = " firmware-imx-vpu-imx8"
+
+IMXBOOT_TARGETS = "flash"
+
+PREFERRED_PROVIDER_imx-sc-firmware = "imx-sc-firmware-toradex"
+BOARD_TYPE = "apalis"
+
+IMAGE_CLASSES_append = " image_type_tezi"
+IMAGE_FSTYPES += "teziimg"
+
+# The imx-boot container takes care for the i.MX 8 offset, so the container
+# has to be flashed at offset 0 directly
+UBOOT_BINARY_TEZI_EMMC = "imx-boot"
+OFFSET_BOOTROM_PAYLOAD = "0"
+
+TEZI_EXTERNAL_KERNEL_DEVICETREE_BOOT = "apalis-imx8x_smartrack_overlay.dtbo"
+
+TORADEX_PRODUCT_IDS = "0046 0053 0054 2600"

--- a/recipes-kernel/linux/device-tree-overlays_git.bb
+++ b/recipes-kernel/linux/device-tree-overlays_git.bb
@@ -1,0 +1,20 @@
+SUMMARY = "SmartRack device tree overlays"
+DESCRIPTION = "SmartRack device tree overlays from within the layer."
+
+SRC_URI = "file://apalis-imx8x_smartrack_overlay.dts file://template_overlay.dts"
+
+inherit devicetree
+
+S = "${WORKDIR}"
+
+COMPATIBLE_MACHINE = ".*(mx[678]).*"
+
+# we have dtbo's in arm and arm64 architecture, set the include paths
+# to include both architectures.
+KERNEL_INCLUDE = " \
+    ${STAGING_KERNEL_DIR}/arch/arm/boot/dts \
+    ${STAGING_KERNEL_DIR}/arch/arm/boot/dts*/* \
+    ${STAGING_KERNEL_DIR}/arch/arm64/boot/dts \
+    ${STAGING_KERNEL_DIR}/arch/arm64/boot/dts/* \
+    ${STAGING_KERNEL_DIR}/scripts/dtc/include-prefixes \
+"

--- a/recipes-kernel/linux/files/apalis-imx8x_smartrack_overlay.dts
+++ b/recipes-kernel/linux/files/apalis-imx8x_smartrack_overlay.dts
@@ -1,0 +1,173 @@
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/pinctrl/pads-imx8qxp.h>
+
+/ {
+    compatible = "toradex,apalis-imx8x";
+
+    /* GPIO: 305, 307, 309, 311 */
+    /* NOT GPIO: none */
+    /* pinctrl_adc0 */
+    fragment@0 {
+        target = <&adc0>;
+        __overlay__ {
+            status = "disabled";
+        };
+    };
+
+    /* GPIO: 243, 245, 247, 255, 257, 259, 261, 265 */
+    /* NOT GPIO: 249, 263, 273, 275, 277, 279, 281, 283, 291, 293, 295, 297, 299, 301 */
+    /* pinctrl_lcdif */
+    fragment@1 {
+        target = <&display_lcdif>;
+        __overlay__ {
+            status = "disabled";
+        };
+    };
+
+    /* GPIO: 2 */
+    /* NOT GPIO: none */
+    /* pinctrl_pwm2 */
+    fragment@2 {
+        target = <&pwm2>;
+        __overlay__ {
+            status = "disabled";
+        };
+    };
+
+    /* GPIO: none */
+    /* NOT GPIO: 4 */
+    /* pinctrl_pwm_mipi_lvds0 */
+    fragment@3 {
+        target = <&pwm_mipi_lvds0>;
+        __overlay__ {
+            status = "disabled";
+        };
+    };
+
+    /* GPIO: none */
+    /* NOT GPIO: 239 */
+    /* pinctrl_pwm_mipi_lvds1 */
+    fragment@4 {
+        target = <&pwm_mipi_lvds1>;
+        __overlay__ {
+            status = "disabled";
+        };
+    };
+
+    /* GPIO: 286 */
+    /* NOT GPIO: none */
+    /* pinctrl_gpio_bkl_on */
+    fragment@5 {
+        target = <&backlight>;
+        __overlay__ {
+            status = "disabled";
+        };
+    };
+
+    fragment@6 {
+        target = <&iomuxc>;
+        __overlay__ {
+            pinctrl-names = "default";
+            pinctrl-0 = <&pinctrl_test>;
+            apalis-imx8qxp {
+                pinctrl_test: gpiomuxgrp {
+                    fsl,pins = <
+                        IMX8QXP_ADC_IN0_LSIO_GPIO1_IO10        0x60 /* MXM3 305 */
+                        IMX8QXP_ADC_IN1_LSIO_GPIO1_IO09        0x60 /* MXM3 307 */
+                        IMX8QXP_ADC_IN4_LSIO_GPIO1_IO14        0x60 /* MXM3 309 */
+                        IMX8QXP_ADC_IN5_LSIO_GPIO1_IO13        0x60 /* MXM3 311 */
+                        IMX8QXP_MCLK_OUT0_LSIO_GPIO0_IO20      0x60 /* MXM3 243 */
+                        IMX8QXP_MCLK_IN0_LSIO_GPIO0_IO19       0x60 /* MXM3 245 */
+                        IMX8QXP_SPI3_CS0_LSIO_GPIO0_IO16       0x60 /* MXM3 247 */
+                        IMX8QXP_SPDIF0_EXT_CLK_LSIO_GPIO0_IO12 0x60 /* MXM3 255 */
+                        IMX8QXP_SPI3_SCK_LSIO_GPIO0_IO13       0x60 /* MXM3 257 */
+                        IMX8QXP_SPI3_SDO_LSIO_GPIO0_IO14       0x60 /* MXM3 259 */
+                        IMX8QXP_SPI3_SDI_LSIO_GPIO0_IO15       0x60 /* MXM3 261 */
+                        IMX8QXP_UART1_CTS_B_LSIO_GPIO0_IO24    0x60 /* MXM3 265 */
+                        IMX8QXP_QSPI0A_DQS_LSIO_GPIO3_IO13     0x21 /* MXM3 286 */
+                    >;
+                };
+                pinctrl_lpi2c4: lpi2c4grp {
+                    fsl,pins = <
+                        IMX8QXP_MIPI_DSI1_GPIO0_00_ADMA_I2C2_SCL 0xc6000020 /* MXM3 239 */
+                        IMX8QXP_MIPI_DSI1_GPIO0_01_ADMA_I2C2_SDA 0xc6000020 /* MXM3 8 */
+                    >;
+                };
+                pinctrl_lpi2c5: lpi2c5grp {
+                    fsl,pins = <
+                        IMX8QXP_CSI_PCLK_MIPI_CSI0_I2C0_SCL 0xc6000020 /* MXM3 191 */
+                        IMX8QXP_CSI_MCLK_MIPI_CSI0_I2C0_SDA 0xc6000020 /* MXM3 193 */
+                    >;
+                };
+                pinctrl_i2c0_mipi_lvds0: mipilvds0i2c0grp {
+                    fsl,pins = <
+                        IMX8QXP_MIPI_DSI0_I2C0_SCL_MIPI_DSI0_I2C0_SCL 0xc6000020 /* MXM3 35 */
+                        IMX8QXP_MIPI_DSI0_I2C0_SDA_MIPI_DSI0_I2C0_SDA 0xc6000020 /* MXM3 37 */
+                    >;
+                };
+            };
+        };
+    };
+
+    /* I2C2: 205, 207 */
+    fragment@7 {
+        target = <&i2c0_mipi_lvds1>;
+        __overlay__ {
+            status = "okay";
+        };
+    };
+
+    /* I2C3: 203, 201 */
+    fragment@8 {
+        target = <&i2c3>;
+        __overlay__ {
+            status = "okay";
+        };
+    };
+
+    fragment@9 {
+        target = <&i2c2>;
+        __overlay__ {
+            #address-cells = <1>;
+            #size-cells = <0>;
+            pinctrl-names = "default";
+            pinctrl-0 = <&pinctrl_lpi2c4>;
+            clock-frequency = <100000>;
+            status = "okay";
+        };
+    };
+
+    fragment@10 {
+        target = <&i2c0_mipi_lvds0>;
+        __overlay__ {
+            #address-cells = <1>;
+            #size-cells = <0>;
+            pinctrl-names = "default";
+            pinctrl-0 = <&pinctrl_i2c0_mipi_lvds0>;
+            clock-frequency = <100000>;
+            status = "okay";
+        };
+    };
+
+    fragment@11 {
+        target = <&i2c_mipi_csi0>;
+        __overlay__ {
+            #address-cells = <1>;
+            #size-cells = <0>;
+            pinctrl-names = "default";
+            pinctrl-0 = <&pinctrl_lpi2c5>;
+            clock-frequency = <100000>;
+            status = "okay";
+        };
+    };
+
+    /* Enable interrupt parent for i2c_mipi_csi0 */
+    fragment@12 {
+        target = <&irqsteer_csi0>;
+        __overlay__ {
+            status = "okay";
+        };
+    };
+};

--- a/recipes-kernel/linux/files/template.dts
+++ b/recipes-kernel/linux/files/template.dts
@@ -1,0 +1,6 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+    compatible = "toradex,apalis-imx8x";
+};


### PR DESCRIPTION
The apalis-imx8x_smartrack_overlay.dts enables i2c buses and muxes certain pins to GPIO. Using a customized device-tree-overlays_git.bb (which shadows the one provided in meta-toradex-nxp), this overlay is installed into the RCU image bootfs partition. The customized apalis-imx8x.conf file in meta-smartrack/conf/machine then instructs overlay.txt file in the bootfs partition to point to our overlay.