### PR TITLE
Pushing minor changes

### DIFF
--- a/recipes-core/rcu-service/rcu-service_1.0.bb
+++ b/recipes-core/rcu-service/rcu-service_1.0.bb
@@ -9,7 +9,7 @@ SYSTEMD_SERVICE_${PN} = "rcu-service.service"
 
 # TODO: Point to release branch when it is ready.
 # If EXTERNAL_SRC was specified, it will take precedence of SRC_URI and SRC_REV
-SRC_URI = "git://github.com/ni/rcu-service.git;branch=main"
+SRC_URI = "git://github.com/ni/rcu-service.git;branch=main;protocol=https"
 
 # TODO: Assign to a fixed revision after release
 SRCREV = "${AUTOREV}"

--- a/recipes-images/images/smartracks-minimal-image.bb
+++ b/recipes-images/images/smartracks-minimal-image.bb
@@ -14,6 +14,10 @@ IMAGE_NAME = "${MACHINE_NAME}_${IMAGE_BASENAME}"
 COPY_LIC_MANIFEST ?= "1"
 COPY_LIC_DIRS ?= "1"
 
+# Configure base image root account default password
+inherit extrausers
+EXTRA_USERS_PARAMS = "usermod -P ni root;"
+
 add_rootfs_version () {
     printf "${DISTRO_NAME} ${DISTRO_VERSION} (${DISTRO_CODENAME}) \\\n \\\l\n" > ${IMAGE_ROOTFS}/etc/issue
     printf "${DISTRO_NAME} ${DISTRO_VERSION} (${DISTRO_CODENAME}) %%h\n" > ${IMAGE_ROOTFS}/etc/issue.net
@@ -27,7 +31,7 @@ IMAGE_LINGUAS = "en-us"
 #IMAGE_LINGUAS = "de-de fr-fr en-gb en-us pt-br es-es kn-in ml-in ta-in"
 
 CONMANPKGS ?= "connman connman-plugin-loopback connman-plugin-ethernet connman-plugin-wifi connman-client"
-SMARTRACKSPKGS ?= "i2c-tools vsftpd python3 rauc dtc rcu-hostname coreutils rcu-service"
+SMARTRACKSPKGS ?= "i2c-tools vsftpd rauc rcu-hostname coreutils rcu-service"
 
 IMAGE_INSTALL += " \
     packagegroup-boot \


### PR DESCRIPTION
- Remove packages for development use only (dtc, python) from smartracks image recipe.
- Add default password to root account of base image
- Fix use of https protocol for rcu-service fetching