### PR TITLE
Include nativesdk-make into SDK

### DIFF
--- a/recipes-images/images/smartracks-minimal-image.bb
+++ b/recipes-images/images/smartracks-minimal-image.bb
@@ -47,5 +47,5 @@ IMAGE_INSTALL += " \
 "
 
 # Required to append protobuf and grpc dependencies to SDK
-TOOLCHAIN_HOST_TASK_append += " nativesdk-protobuf-compiler nativesdk-grpc-dev nativesdk-python3-grpcio-tools "
+TOOLCHAIN_HOST_TASK_append += " nativesdk-protobuf-compiler nativesdk-grpc-dev nativesdk-python3-grpcio-tools nativesdk-make "
 TOOLCHAIN_TARGET_TASK_append += " python3-grpcio-tools "


### PR DESCRIPTION
Running cmake in host requires `make` to present in the host as well.
Instead of asking user to install `make` or build-essential package, we add it into the SDK
so that we can control its version and every user who use the SDK will use the same version of `make`.