### PR TITLE
Fix OE builds involving RCU Service recipes

### DIFF
--- a/recipes-core/rcu-service/rcu-service-cpp.inc
+++ b/recipes-core/rcu-service/rcu-service-cpp.inc
@@ -1,7 +1,7 @@
 S = "${WORKDIR}/git"
 TARGET_CC_ARCH += "${LDFLAGS}"
 
-DEPENDS = " protobuf-native grpc grpc-native "
+DEPENDS = " protobuf-native grpc grpc-native libgpiod "
 
 inherit cmake
 

--- a/recipes-core/rcu-service/rcu-service-python-test-client_1.0.bb
+++ b/recipes-core/rcu-service/rcu-service-python-test-client_1.0.bb
@@ -15,7 +15,7 @@ do_compile() {
 
 do_install() {
 	install -d ${D}${bindir}
-	install -m 0755 ${S}/tests/python/rcu-service-python-test-client.py ${D}${bindir}
+	install -m 0755 ${S}/tests/python/rcupyclient.py ${D}${bindir}
 	install -m 0755 ${S}/tests/python/rcu_service_pb2.py ${D}${bindir}
 	install -m 0755 ${S}/tests/python/rcu_service_pb2_grpc.py ${D}${bindir}
 }


### PR DESCRIPTION
- RCU Client Python module renamed from rcu-service-python-test-client to rcupyclient
- Add libgpiod to rcu-service recipe dependency