### PR TITLE
Move rcu-service recipe S variable specification from cpp.inc to src.inc

### DIFF
--- a/recipes-core/rcu-service/rcu-service-cpp.inc
+++ b/recipes-core/rcu-service/rcu-service-cpp.inc
@@ -1,4 +1,3 @@
-S = "${WORKDIR}/git"
 TARGET_CC_ARCH += "${LDFLAGS}"
 
 DEPENDS = " protobuf-native grpc grpc-native libgpiod "

--- a/recipes-core/rcu-service/rcu-service-src.inc
+++ b/recipes-core/rcu-service/rcu-service-src.inc
@@ -4,3 +4,5 @@ SRC_URI = "git://github.com/ni/rcu-service.git;branch=main;protocol=https"
 
 # TODO: Assign to a fixed revision after release
 SRCREV = "${AUTOREV}"
+
+S = "${WORKDIR}/git"


### PR DESCRIPTION
Placing S = "${WORKDIR}/git" in rcu-service-cpp.inc causes the rcu-service-python-test-client recipe to fail offline builds due to not using the correct default directory locating recipe source code. This is because rcu-service-cpp.inc is not used by that recipe. Moving the statement to rcu-service-src.inc fixes the issue, as rcu-service-src.inc is required by both RCU Service cpp and Python recipes. 