### PR TITLE
change initial state of I2C3

### DIFF
--- a/recipes-kernel/linux/files/imx8qxp-apalis-smartracks.dtsi
+++ b/recipes-kernel/linux/files/imx8qxp-apalis-smartracks.dtsi
@@ -182,8 +182,8 @@
         gpio-controller;
         #gpio-cells = <2>;
         label = "pca9674-5a830000.gpio";
-        /* IO0 and IO1 has to be output low by default */
-        lines-initial-states = <0x03>;
+        /* IO0 and IO1 has to be output high by default */
+        lines-initial-states = <0x00>;
         gpio-line-names =
             "IOXPD2_IO0_0", "IOXPD2_IO0_1", "IOXPD2_IO0_2", "IOXPD2_IO0_3", "IOXPD2_IO0_4", "IOXPD2_IO0_5", "IOXPD2_IO0_6", "IOXPD2_IO0_7";
     };


### PR DESCRIPTION
Hardware engineers reworked PEP FAN and PEP AUX to be active low so they have to be default high. Hence, setting I2C3 default to "output high" by setting bit 0 and bit 1 of the bit mask to 0.