### PR TITLE
Add rcu-version template files

### DIFF
--- a/recipes-core/rcu-image-version/rcu-image-version.bb
+++ b/recipes-core/rcu-image-version/rcu-image-version.bb
@@ -2,10 +2,10 @@ LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 
 SRC_URI = "\
-    file://rcu-version \
+    file://rcu-image-version \
 "
 
 do_install () {
     install -d ${D}${sysconfdir}
-    install -m 0644 ${WORKDIR}/rcu-version ${D}${sysconfdir}
+    install -m 0644 ${WORKDIR}/rcu-image-version ${D}${sysconfdir}
 }

--- a/recipes-core/rcu-version/rcu-version.bb
+++ b/recipes-core/rcu-version/rcu-version.bb
@@ -1,0 +1,11 @@
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+SRC_URI = "\
+    file://rcu-version \
+"
+
+do_install () {
+    install -d ${D}${sysconfdir}
+    install -m 0644 ${WORKDIR}/rcu-version ${D}${sysconfdir}
+}

--- a/recipes-images/images/packagegroup-ni-cli.bb
+++ b/recipes-images/images/packagegroup-ni-cli.bb
@@ -22,6 +22,7 @@ RRECOMMENDS_packagegroup-base-ni-cli = "\
     rcu-hostname \
     coreutils \
     rcu-service \
+    rcu-image-version \
     udev-ni-rules \
     keyutils \
     cifs-utils \


### PR DESCRIPTION
PR adds an empty rcu-version file which is appended to /etc directory. This file should be modified by pipeline, which inserts the build number, allowing users to cat /etc/rcu-version to know the version of which rcu-image they are running.