### PR TITLE
Relocate RCU Service Python Dependencies

### DIFF
--- a/recipes-core/rcu-service/rcu-service-cpp.inc
+++ b/recipes-core/rcu-service/rcu-service-cpp.inc
@@ -1,6 +1,6 @@
 TARGET_CC_ARCH += "${LDFLAGS}"
 
-DEPENDS = " protobuf-native grpc grpc-native libgpiod "
+DEPENDS += " protobuf-native grpc grpc-native libgpiod "
 
 inherit cmake
 

--- a/recipes-core/rcu-service/rcu-service-python-test-client_1.0.bb
+++ b/recipes-core/rcu-service/rcu-service-python-test-client_1.0.bb
@@ -5,13 +5,6 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda
 
 require rcu-service-src.inc
 
-DEPENDS += " python3-grpcio-tools-native"
-RDEPENDS_${PN} += " python3 python3-grpcio "
-inherit python3native
-inherit python3-dir
-
-FILES_${PN} += "${PYTHON_SITEPACKAGES_DIR}"
-
 do_compile() {
 	python3 -m grpc_tools.protoc -I${S} --python_out=${S}/tests/python --grpc_python_out=${S}/tests/python ${S}/rcu-service.proto
 }

--- a/recipes-core/rcu-service/rcu-service-src.inc
+++ b/recipes-core/rcu-service/rcu-service-src.inc
@@ -6,3 +6,10 @@ SRC_URI = "git://github.com/ni/rcu-service.git;branch=main;protocol=https"
 SRCREV = "${AUTOREV}"
 
 S = "${WORKDIR}/git"
+
+DEPENDS += " python3-grpcio-tools-native"
+RDEPENDS_${PN} += " python3 python3-grpcio "
+inherit python3native
+inherit python3-dir
+
+FILES_${PN} += "${PYTHON_SITEPACKAGES_DIR}"


### PR DESCRIPTION
Following the latest changes in RCU Service build process, Python dependencies are also required to build rcu-service.cpp. This PR relocates Python dependencies from the rcu-service-python-test-client recipe to rcu-service-src, which is included by all rcu-service recipes. 