### PR TITLE
Adding PCA9552 16-bit LED driver to RCU Device Tree

### DIFF
--- a/recipes-kernel/linux/files/imx8qxp-apalis-smartracks.dtsi
+++ b/recipes-kernel/linux/files/imx8qxp-apalis-smartracks.dtsi
@@ -226,6 +226,79 @@
         compatible = "dallas,ds3232";
         reg = <0x68>;
     };
+    
+    /* 16-bit LED driver */
+    pca9552: pca9552@62 {
+        compatible = "nxp,pca9552";
+        #address-cells = <1>;
+        #size-cells = <0>;
+        reg = <0x62>;
+
+        led@0 {
+            reg = <0>;
+            type = <PCA955X_TYPE_LED>;
+        };
+        led@1 {
+            reg = <1>;
+            type = <PCA955X_TYPE_LED>;
+        };
+        led@2 {
+            reg = <2>;
+            type = <PCA955X_TYPE_LED>;
+        };
+        led@3 {
+            reg = <3>;
+            type = <PCA955X_TYPE_LED>;
+        };
+        led@4 {
+            reg = <4>;
+            type = <PCA955X_TYPE_LED>;
+        };
+        led@5 {
+            reg = <5>;
+            type = <PCA955X_TYPE_LED>;
+        };
+        led@6 {
+            reg = <6>;
+            type = <PCA955X_TYPE_LED>;
+        };
+        led@7 {
+            reg = <7>;
+            type = <PCA955X_TYPE_LED>;
+        };
+        led@8 {
+            reg = <8>;
+            type = <PCA955X_TYPE_LED>;
+        };
+        led@9 {
+            reg = <9>;
+            type = <PCA955X_TYPE_LED>;
+        };
+        led@10 {
+            reg = <10>;
+            type = <PCA955X_TYPE_LED>;
+        };
+        led@11 {
+            reg = <11>;
+            type = <PCA955X_TYPE_LED>;
+        };
+        led@12 {
+            reg = <12>;
+            type = <PCA955X_TYPE_LED>;
+        };
+        led@13 {
+            reg = <13>;
+            type = <PCA955X_TYPE_LED>;
+        };
+        led@14 {
+            reg = <14>;
+            type = <PCA955X_TYPE_LED>;
+        };
+        led@15 {
+            reg = <15>;
+            type = <PCA955X_TYPE_LED>;
+        };
+    };
 };
 
 /* Apalis I2C5 (58226000.i2c) MXM3 191, 193 */


### PR DESCRIPTION
Justification:
- To ease hardware V&V, so that hardware engineer can control the LEDs via driver instead of have to perform raw I2C transaction

Description:
- Kernel driver was enabled in https://github.com/ni/meta-smartracks/pull/42
- Location of this LED driver: I2C Bus: 0x04; I2C Addr: 0x62
- DT binding guide: https://github.com/torvalds/linux/blob/master/Documentation/devicetree/bindings/leds/leds-pca955x.txt

Testing:
- Have not tested it as I don't have a board with me. Will work with hardware engineer to test it once the export is ready


