### PR TITLE
Fix Diodes 48-bit GPIO Expander patch

### DIFF
--- a/recipes-kernel/linux/files/add-support-for-diodes-pi4ioe5v96248.patch
+++ b/recipes-kernel/linux/files/add-support-for-diodes-pi4ioe5v96248.patch
@@ -1,5 +1,5 @@
---- a/drivers/gpio/gpio-pcf857x.c	2021-06-10 04:00:37.797098202 -0700
-+++ b/drivers/gpio/gpio-pcf857x.c	2021-06-18 04:42:29.277147818 -0700
+--- a/drivers/gpio/gpio-pcf857x.c	2021-11-03 14:38:34.649483661 +0800
++++ b/drivers/gpio/gpio-pcf857x.c	2021-11-03 15:12:18.106800496 +0800
 @@ -17,6 +17,7 @@
  #include <linux/of_device.h>
  #include <linux/slab.h>
@@ -263,3 +263,12 @@
  
  	gpio->client = client;
  	i2c_set_clientdata(client, gpio);
+@@ -332,7 +388,7 @@
+ 	 * reset state.  Otherwise it flags pins to be driven low.
+ 	 */
+ 	gpio->out = ~n_latch;
+-	gpio->status = gpio->read(gpio->client);
++	gpio->status = gpio->read(gpio->client, &value);
+ 
+ 	status = devm_gpiochip_add_data(&client->dev, &gpio->chip, gpio);
+ 	if (status < 0)


### PR DESCRIPTION
Patch fix for Diodes GPIO Expander. This patch will be applicable if we bump git hashes in smartracks-manifest, here:
https://github.com/ni/smartracks-manifest/pull/10

Latest modified driver can be found here:
https://github.com/HatsyRei/diodes/blob/master/gpio-diodes.c