### PR TITLE
Add i2c mux into device tree

### DIFF
--- a/recipes-kernel/linux/files/imx8-apalis-smartracks.dtsi
+++ b/recipes-kernel/linux/files/imx8-apalis-smartracks.dtsi
@@ -16,7 +16,7 @@
         status = "okay";
     };
 
-    /* I2C Analog Mux attached to Apalis I2C5 */
+    /* I2C Analog Mux attached to RCU's I2C5 */
     /* MXM3 196 (lsio_gpio3 line 12) and MXM3 198 (lsio_gpio2 line 7) occupied by mux driver */
     i2cmux-56247000.i2c {
         compatible = "i2c-mux-gpio";

--- a/recipes-kernel/linux/files/imx8-apalis-smartracks.dtsi
+++ b/recipes-kernel/linux/files/imx8-apalis-smartracks.dtsi
@@ -236,6 +236,37 @@
     clock-frequency = <100000>;
 };
 
+/* I2C Analog Mux attached to Apalis I2C5 */
+/* MXM3 196 (lsio_gpio3 line 12) and MXM3 198 (lsio_gpio2 line 7) occupied by mux driver */
+i2cmux-56247000.i2c {
+    compatible = "i2c-mux-gpio";
+    #address-cells = <1>;
+    #size-cells = <0>;
+    mux-gpios = <&lsio_gpio3 12 GPIO_ACTIVE_HIGH &lsio_gpio2 7 GPIO_ACTIVE_HIGH>;
+    i2c-parent = <&i2c1_lvds0>;
+
+    i2c@0 {
+        reg = <0>;
+        #address-cells = <1>;
+        #size-cells = <0>;
+    };
+    i2c@1 {
+        reg = <1>;
+        #address-cells = <1>;
+        #size-cells = <0>;
+    };
+    i2c@2 {
+        reg = <2>;
+        #address-cells = <1>;
+        #size-cells = <0>;
+    };
+    i2c@3 {
+        reg = <3>;
+        #address-cells = <1>;
+        #size-cells = <0>;
+    };
+};
+
 &iomuxc {
     pinctrl-names = "default";
     pinctrl-0 = <&pinctrl_rcugpio>, <&pinctrl_cam1_gpios>, <&pinctrl_dap1_gpios>,

--- a/recipes-kernel/linux/files/imx8-apalis-smartracks.dtsi
+++ b/recipes-kernel/linux/files/imx8-apalis-smartracks.dtsi
@@ -15,6 +15,37 @@
     panel_lvds: panel-lvds {
         status = "okay";
     };
+
+    /* I2C Analog Mux attached to Apalis I2C5 */
+    /* MXM3 196 (lsio_gpio3 line 12) and MXM3 198 (lsio_gpio2 line 7) occupied by mux driver */
+    i2cmux-56247000.i2c {
+        compatible = "i2c-mux-gpio";
+        #address-cells = <1>;
+        #size-cells = <0>;
+        mux-gpios = <&lsio_gpio3 12 GPIO_ACTIVE_HIGH &lsio_gpio2 7 GPIO_ACTIVE_HIGH>;
+        i2c-parent = <&i2c1_lvds0>;
+
+        i2c@0 {
+            reg = <0>;
+            #address-cells = <1>;
+            #size-cells = <0>;
+        };
+        i2c@1 {
+            reg = <1>;
+            #address-cells = <1>;
+            #size-cells = <0>;
+        };
+        i2c@2 {
+            reg = <2>;
+            #address-cells = <1>;
+            #size-cells = <0>;
+        };
+        i2c@3 {
+            reg = <3>;
+            #address-cells = <1>;
+            #size-cells = <0>;
+        };
+    };
 };
 
 /* Apalis ADC signals */
@@ -234,37 +265,6 @@
     #address-cells = <1>;
     #size-cells = <0>;
     clock-frequency = <100000>;
-};
-
-/* I2C Analog Mux attached to Apalis I2C5 */
-/* MXM3 196 (lsio_gpio3 line 12) and MXM3 198 (lsio_gpio2 line 7) occupied by mux driver */
-i2cmux-56247000.i2c {
-    compatible = "i2c-mux-gpio";
-    #address-cells = <1>;
-    #size-cells = <0>;
-    mux-gpios = <&lsio_gpio3 12 GPIO_ACTIVE_HIGH &lsio_gpio2 7 GPIO_ACTIVE_HIGH>;
-    i2c-parent = <&i2c1_lvds0>;
-
-    i2c@0 {
-        reg = <0>;
-        #address-cells = <1>;
-        #size-cells = <0>;
-    };
-    i2c@1 {
-        reg = <1>;
-        #address-cells = <1>;
-        #size-cells = <0>;
-    };
-    i2c@2 {
-        reg = <2>;
-        #address-cells = <1>;
-        #size-cells = <0>;
-    };
-    i2c@3 {
-        reg = <3>;
-        #address-cells = <1>;
-        #size-cells = <0>;
-    };
 };
 
 &iomuxc {


### PR DESCRIPTION
In the RCU design, an i2c mux is connected to RCU's I2C5 to control several Temperature Sensors. The mux's selector is connected to two GPIOs from the RCU as control pins. This i2c mux node is ported from Rev A. Changes made were:
1. mux address label (follow its parent i2c port)
2. parent i2c node
3. mux gpios (gpio group and line number change)