### PR TITLE
Instantiate Onboard Temp sensor through device tree

### DIFF
--- a/recipes-kernel/linux/files/imx8qxp-apalis-smartracks.dtsi
+++ b/recipes-kernel/linux/files/imx8qxp-apalis-smartracks.dtsi
@@ -4,6 +4,7 @@
     aliases {
         rtc1 = &rtc_i2c;
         rtc0 = &rtc;
+        temp0 = &temp_i2c;
     };
 
     reg_3v3: regulator-3v3 {
@@ -227,6 +228,13 @@
     rtc_i2c: rtc@68 {
         compatible = "dallas,ds3232";
         reg = <0x68>;
+    };
+    
+    /* Onboard Temperature Sensor TMP1075 */
+    temp_i2c: temp@4F {
+        status = "okay";
+        compatible = "lm75";
+        reg = <0x4F>;
     };
     
     /* 16-bit LED driver */

--- a/recipes-kernel/linux/files/imx8qxp-apalis-smartracks.dtsi
+++ b/recipes-kernel/linux/files/imx8qxp-apalis-smartracks.dtsi
@@ -4,7 +4,6 @@
     aliases {
         rtc1 = &rtc_i2c;
         rtc0 = &rtc;
-        temp0 = &temp_i2c;
     };
 
     reg_3v3: regulator-3v3 {
@@ -232,9 +231,9 @@
     
     /* Onboard Temperature Sensor TMP1075 */
     temp_i2c: temp@4F {
-        status = "okay";
-        compatible = "lm75";
+        compatible = "national,lm75";
         reg = <0x4F>;
+        status = "okay";
     };
     
     /* 16-bit LED driver */


### PR DESCRIPTION
Add the onboard temperature sensor to the device tree.
Tested on Gamora rack that the onboard temperature can be detected and driver can be loaded.

Signed-off-by: NI-CHO <cheng.hong.ong@ni.com>