### PR TITLE
Instantiate Onboard Temp sensor through device tree

### DIFF
--- a/recipes-kernel/linux/files/imx8-apalis-smartracks.dtsi
+++ b/recipes-kernel/linux/files/imx8-apalis-smartracks.dtsi
@@ -173,6 +173,13 @@
         reg = <0x68>;
     };
 
+    /* Onboard Temperature Sensor TMP1075 */
+    temp_i2c: temp@4F {
+        compatible = "national,lm75";
+        reg = <0x4F>;
+        status = "okay";
+    };
+
     /* 16-bit LED driver */
     pca9552: pca9552@62 {
         compatible = "nxp,pca9552";


### PR DESCRIPTION
Add the onboard temperature sensor to the device tree.
Signed-off-by: NI-CHO <cheng.hong.ong@ni.com>