### PR TITLE
changes to support Rev B bringup

### DIFF
--- a/buildconf/local.conf
+++ b/buildconf/local.conf
@@ -24,6 +24,9 @@ ACCEPT_FSL_EULA = "1"
 
 MACHINE ?= "apalis-imx8"
 
+# NOTE: Append KERNEL_DEVICETREE to insert imx8-apalis-smartracks.dtb into
+# apalis-imx8.conf. This will ensure the dtb to be built into our custom image.
+
 KERNEL_DEVICETREE_append = " freescale/imx8-apalis-smartracks.dtb"
 
 #

--- a/buildconf/local.conf
+++ b/buildconf/local.conf
@@ -24,6 +24,8 @@ ACCEPT_FSL_EULA = "1"
 
 MACHINE ?= "apalis-imx8"
 
+KERNEL_DEVICETREE_append = " freescale/imx8-apalis-smartracks.dtb"
+
 #
 # There are also a selection of emulated machines available which can boot and run
 # in the QEMU emulator:

--- a/recipes-bsp/u-boot/files/alter-default-apalis-device-tree.patch
+++ b/recipes-bsp/u-boot/files/alter-default-apalis-device-tree.patch
@@ -1,35 +1,26 @@
-From d38c215a0fbc4023ceaeb13bb873d5dd940a9e15 Mon Sep 17 00:00:00 2001
+From 98b9a3eafa5e664c2f5d6aa2a09f57c4c44fa989 Mon Sep 17 00:00:00 2001
 From: wkoe <wilson.koe@ni.com>
 Date: Mon, 14 Mar 2022 20:53:28 -0700
 Subject: [PATCH] alter default apalis device tree
 
 Signed-off-by: wkoe <wilson.koe@ni.com>
 ---
- include/configs/apalis-imx8.h | 4 +++-
- 1 file changed, 3 insertions(+), 1 deletion(-)
+ configs/apalis-imx8_defconfig | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
 
-diff --git a/include/configs/apalis-imx8.h b/include/configs/apalis-imx8.h
-index 5532f8e03f..fdfcbb1baa 100644
---- a/include/configs/apalis-imx8.h
-+++ b/include/configs/apalis-imx8.h
-@@ -92,6 +92,8 @@
- #  define BOOT_SCRIPT	"boot.scr"
- #endif
- 
-+#define FDT_FILE			"imx8-apalis-smartracks.dtb"
-+
- /* Initial environment variables */
- #define CONFIG_EXTRA_ENV_SETTINGS \
- 	AHAB_ENV \
-@@ -105,7 +107,7 @@
- 	"console=ttyLP1 earlycon\0" \
- 	"fdt_high=\0" \
- 	"boot_fdt=try\0" \
--	"fdt_board=eval\0" \
-+	"fdtfile=" FDT_FILE "\0" \
- 	"finduuid=part uuid mmc ${mmcdev}:2 uuid\0" \
- 	"hdp_file=hdmitxfw.bin\0" \
- 	"loadhdp=${load_cmd} ${hdp_addr} ${hdp_file}\0" \
+diff --git a/configs/apalis-imx8_defconfig b/configs/apalis-imx8_defconfig
+index 42700e4571..4b087e36dd 100644
+--- a/configs/apalis-imx8_defconfig
++++ b/configs/apalis-imx8_defconfig
+@@ -17,7 +17,7 @@ CONFIG_FIT=y
+ CONFIG_FIT_VERBOSE=y
+ CONFIG_OF_SYSTEM_SETUP=y
+ CONFIG_USE_PREBOOT=y
+-CONFIG_PREBOOT="setenv fdtfile ${soc}-apalis${variant}-${fdt_board}.dtb"
++CONFIG_PREBOOT="setenv fdtfile imx8-apalis-smartracks.dtb"
+ CONFIG_SYS_EXTRA_OPTIONS="IMX_CONFIG=board/toradex/apalis-imx8/apalis-imx8-imximage.cfg"
+ CONFIG_BOOTDELAY=1
+ CONFIG_LOG=y
 -- 
 2.17.1
 

--- a/recipes-kernel/linux/files/imx8-apalis-smartracks.dtsi
+++ b/recipes-kernel/linux/files/imx8-apalis-smartracks.dtsi
@@ -7,15 +7,6 @@
         rtc1 = &rtc;
     };
 
-    /* Apalis BKL1 */
-    backlight: backlight {
-        pinctrl-0 = <&pinctrl_bkl_on>;
-    };
-
-    panel_lvds: panel-lvds {
-        status = "okay";
-    };
-
     /* I2C Analog Mux attached to RCU's I2C5 */
     /* MXM3 196 (lsio_gpio3 line 12) and MXM3 198 (lsio_gpio2 line 7) occupied by mux driver */
     i2cmux-56247000.i2c {
@@ -48,6 +39,16 @@
     };
 };
 
+/* Disable pcie switch to mux pin MXM3 15 for GPIO function. */
+&reg_pcie_switch {
+    status = "disabled";
+};
+
+/* Disable gpio fan to mux pin MXM3 17 for GPIO function. */
+&gpio_fan {
+    status = "disabled";
+};
+
 /* Apalis ADC signals */
 /* Disable adc0 to mux pin MXM3 305 for GPIO function. */
 &adc0 {
@@ -64,14 +65,43 @@
     status = "disabled";
 };
 
+/* Apalis First Gigabit Ethernet */
+&fec1 {
+    status = "okay";
+
+    mdio {
+        ethphy0: ethernet-phy@7 {
+            /delete-property/ interrupt-parent;
+            /delete-property/ interrupts;
+            /delete-property/ reset-assert-us;
+            /delete-property/ reset-deassert-us;
+            /delete-property/ reset-gpios;
+            /delete-property/ reset-names;
+        };
+    };
+};
+
 /* Apalis Second Gigabit Ethernet */
 &fec2 {
     status = "okay";
     pinctrl-names = "default";
     pinctrl-0 = <&pinctrl_fec2>;
     fsl,magic-packet;
-    phy-handle = <&ethphy0>;
+    fsl,mii-exclusive;
+    phy-handle = <&ethphy1>;
     phy-mode = "rgmii-id";
+
+    mdio {
+        #address-cells = <1>;
+        #size-cells = <0>;
+
+        ethphy1: ethernet-phy@7 {
+            compatible = "ethernet-phy-ieee802.3-c22";
+            micrel,led-mode = <0>;
+            reg = <7>;
+            max-speed = <100>;
+        };
+    };
 };
 
 /* Apalis CAN1 */
@@ -106,6 +136,21 @@
     clock-frequency = <400000>;
 };
 
+/* Parent node to enable i2c0_mipi1 */
+&irqsteer_mipi1 {
+    status = "okay";
+};
+
+/* Parent node to enable i2c0_mipi1 */
+&mipi1_dphy {
+    status = "okay";
+};
+
+/* Parent node to enable i2c0_mipi1 */
+&mipi1_dsi_host {
+    status = "okay";
+};
+
 /* RCU's I2C3 */
 &i2c0_mipi1 {
     status = "okay";
@@ -127,6 +172,21 @@
         gpio-line-names =
             "IOXPD2_IO0_0", "IOXPD2_IO0_1", "IOXPD2_IO0_2", "IOXPD2_IO0_3", "IOXPD2_IO0_4", "IOXPD2_IO0_5", "IOXPD2_IO0_6", "IOXPD2_IO0_7";
     };
+};
+
+/* Parent node to enable i2c0_lvds0 & i2c1_lvds0 */
+&ldb1_phy {
+    status = "okay";
+};
+
+/* Parent node to enable i2c0_lvds0 & i2c1_lvds0 */
+&ldb1 {
+    status = "okay";
+};
+
+/* Parent node to enable i2c0_lvds0 & i2c1_lvds0 */
+&irqsteer_lvds0 {
+    status = "okay";
 };
 
 /* RCU's I2C4 */
@@ -264,6 +324,11 @@
     clock-frequency = <100000>;
 };
 
+/* Parent node to enable i2c0_lvds1 */
+&irqsteer_lvds1 {
+    status = "okay";
+};
+
 /* RCU's I2C6 */
 &i2c0_lvds1 {
     status = "okay";
@@ -276,15 +341,8 @@
 
 &iomuxc {
     pinctrl-names = "default";
-    pinctrl-0 = <&pinctrl_rcugpio>, <&pinctrl_cam1_gpios>, <&pinctrl_dap1_gpios>,
-            <&pinctrl_esai0_gpios>, <&pinctrl_fec2_gpios>,
-            <&pinctrl_gpio3>, <&pinctrl_gpio4>, <&pinctrl_gpio_keys>,
-            <&pinctrl_gpio_usbh_oc_n>, <&pinctrl_lpuart1ctrl>,
-            <&pinctrl_lvds0_i2c0_gpio>, <&pinctrl_lvds1_i2c0_gpios>,
-            <&pinctrl_mipi_dsi_0_1_en>, <&pinctrl_mipi_dsi1_gpios>,
-            <&pinctrl_mlb_gpios>, <&pinctrl_qspi1a_gpios>,
-            <&pinctrl_sata1_act>, <&pinctrl_sim0_gpios>,
-            <&pinctrl_usdhc1_gpios>;
+    pinctrl-0 = <&pinctrl_rcugpio>, <&pinctrl_reset_moci>,
+            <&pinctrl_gpio_usbh_oc_n>;
 
     apalis-imx8qm {
         pinctrl_rcugpio: rcugpiogrp {
@@ -610,13 +668,12 @@
 
 /* Apalis USBH2, Apalis USBH3 and on-module Wi-Fi via on-module HSIC Hub */
 &usbh1 {
-    vbus-supply = <&reg_usb_host_vbus>;
-    status = "okay";
+    status = "disabled";
 };
 
 /* This is the usbphy signal required by usbh1. */
 &usbphynop2 {
-    status = "okay";
+    status = "disabled";
 };
 
 /* USB phy signal for USBOTG1 */

--- a/recipes-kernel/linux/linux-toradex_5.4-2.3.x.bbappend
+++ b/recipes-kernel/linux/linux-toradex_5.4-2.3.x.bbappend
@@ -17,5 +17,3 @@ do_configure_prepend() {
     cp ${WORKDIR}/imx8-apalis-smartracks.dtsi ${WORKDIR}/git/arch/arm64/boot/dts/freescale
     cp ${WORKDIR}/imx8-apalis-smartracks.dts ${WORKDIR}/git/arch/arm64/boot/dts/freescale
 }
-
-KERNEL_DEVICETREE_append = " freescale/imx8-apalis-smartracks.dtb"


### PR DESCRIPTION
Add changes made during bring up:
1. Fix Device Tree not built into image
2. Disable all USB interface
3. Fix all GPIO muxing issues to enable all I/O buses
4. Enable Ethernet Port 2