### PR TITLE
Delete no-1-8-v property to enable UHS-I speed for SD card

### DIFF
--- a/recipes-kernel/linux/files/imx8-apalis-smartracks.dtsi
+++ b/recipes-kernel/linux/files/imx8-apalis-smartracks.dtsi
@@ -706,6 +706,7 @@
 &usdhc2 {
     bus-width = <4>;
     status = "okay";
+    /delete-property/ no-1-8-v;
 };
 
 /* Apalis SD1 */

--- a/recipes-kernel/linux/files/imx8-apalis-smartracks.dtsi
+++ b/recipes-kernel/linux/files/imx8-apalis-smartracks.dtsi
@@ -703,7 +703,7 @@
 
 /* RCU's SD1 */
 /* RCU uses Apalis' MMC1 as its SD1, hence the bus-width is reduced to 4 */
-/* Delete 'no-1-8-v' node to enable UHS-I speed for SD card              */
+/* Delete 'no-1-8-v' property to enable UHS-I speed for SD card          */
 &usdhc2 {
     bus-width = <4>;
     status = "okay";

--- a/recipes-kernel/linux/files/imx8-apalis-smartracks.dtsi
+++ b/recipes-kernel/linux/files/imx8-apalis-smartracks.dtsi
@@ -703,6 +703,7 @@
 
 /* RCU's SD1 */
 /* RCU uses Apalis' MMC1 as its SD1, hence the bus-width is reduced to 4 */
+/* Delete 'no-1-8-v' node to enable UHS-I speed for SD card              */
 &usdhc2 {
     bus-width = <4>;
     status = "okay";


### PR DESCRIPTION
Original Device Tree turns off UHS-I by default, according to https://developer.toradex.com/linux-bsp/how-to/peripheral-access/sdmmc-card-linux#sdmmc-card-insertion we need to remove "no-1-8-v" property to enable it. This PR removes this property. SD Card was able to reach ultra high speed after this change:
![image](https://user-images.githubusercontent.com/50833622/173793290-68156041-bd1e-4ca9-9a31-84a83da505e6.png)
![image](https://user-images.githubusercontent.com/50833622/173793377-5b4db80e-f84f-41d7-bf38-5b864bf7c23f.png)
![image](https://user-images.githubusercontent.com/50833622/173793471-68ba4555-936b-4fce-97be-b7b504a31cda.png)

Signed-off-by: wkoe <wilson.koe@ni.com>