### PR TITLE
Edit DISTRO specification in local.conf to build non RT image

### DIFF
--- a/buildconf/local.conf
+++ b/buildconf/local.conf
@@ -256,7 +256,7 @@ INHERIT += "rm_work"
 INHERIT += "toradex-mirrors"
 
 # Use this distro
-DISTRO = "tdx-xwayland-rt"
+DISTRO = "tdx-xwayland"
 
 # Don't generate the mirror tarball for SCM repos, the snapshot is enough
 # BB_GENERATE_MIRROR_TARBALLS = "0"


### PR DESCRIPTION
RCU images with PREEMPT_RT patch applied has spontaneous hanging issues. Investigations are currently underway. Builds will proceed without RT for now to unblock EMC testing and safety.