### PR TITLE
Update RCU image name

### DIFF
--- a/recipes-images/images/smartracks-minimal-image.bb
+++ b/recipes-images/images/smartracks-minimal-image.bb
@@ -1,7 +1,7 @@
 inherit core-image
 
-SUMMARY = "Smart Racks Linux Reference Minimal Image"
-DESCRIPTION = "Minimal image without graphical interface that just boots"
+SUMMARY = "Smart Racks RCU Image"
+DESCRIPTION = "Smart Racks RCU image with preinstalled RCU firmware"
 
 LICENSE = "MIT"
 

--- a/recipes-images/images/smartracks-minimal-image.bb
+++ b/recipes-images/images/smartracks-minimal-image.bb
@@ -6,8 +6,8 @@ DESCRIPTION = "Minimal image without graphical interface that just boots"
 LICENSE = "MIT"
 
 #Prefix to the resulting deployable tarball name
-export IMAGE_BASENAME = "Reference-Minimal-Image"
-MACHINE_NAME ?= "${MACHINE}"
+export IMAGE_BASENAME = "Core-RCU-Image"
+MACHINE_NAME = "NI-ATE"
 IMAGE_NAME = "${MACHINE_NAME}_${IMAGE_BASENAME}"
 
 # Copy Licenses to image /usr/share/common-license

--- a/recipes-images/images/smartracks-minimal-image.bb
+++ b/recipes-images/images/smartracks-minimal-image.bb
@@ -6,8 +6,8 @@ DESCRIPTION = "Minimal image without graphical interface that just boots"
 LICENSE = "MIT"
 
 #Prefix to the resulting deployable tarball name
-export IMAGE_BASENAME = "Core-RCU-Image"
-MACHINE_NAME = "NI-ATE"
+export IMAGE_BASENAME = "RCU-Image"
+MACHINE_NAME = "NI-ATE-Core"
 IMAGE_NAME = "${MACHINE_NAME}_${IMAGE_BASENAME}"
 
 # Copy Licenses to image /usr/share/common-license


### PR DESCRIPTION
A follow up to https://github.com/ni/smartracks-script/pull/16#discussion_r902212864, suggestions to rename RCU image name in Yocto layer instead of performing the rename in build pipeline.

An example of the resulting TEZI image tar name after making the changes:
> NI-ATE-Core_RCU-Image-Tezi_5.7.0-devel-20220622061006+build.0.tar