### PR TITLE
Enforce running rcu-hostname.service before avahi-daemon.service

### DIFF
--- a/recipes-core/rcu-hostname/files/rcu-hostname.service
+++ b/recipes-core/rcu-hostname/files/rcu-hostname.service
@@ -2,6 +2,7 @@
 #ConditionPathExists=|!/etc/hostname
 Wants=network-pre.target
 Before=network-pre.target
+# Make sure that ni-smartracks hostname is set before avahi-daemon registers hostname to DNS
 Before=avahi-daemon.service
 After=local-fs.target
 After=sys-subsystem-net-devices-eth0.device

--- a/recipes-core/rcu-hostname/files/rcu-hostname.service
+++ b/recipes-core/rcu-hostname/files/rcu-hostname.service
@@ -2,6 +2,7 @@
 #ConditionPathExists=|!/etc/hostname
 Wants=network-pre.target
 Before=network-pre.target
+Before=avahi-daemon.service
 After=local-fs.target
 After=sys-subsystem-net-devices-eth0.device
 


### PR DESCRIPTION
On RCU boot, avahi-daemon may register default Apalis hostname to DNS server instead of the `ni-smartracks` hostname if avahi-daemon runs prior to rcu-hostname. Changes in this PR should allow rcu-hostname to always run before avahi-daemon.