### PR TITLE
Remove Conflicting Toradex Packages from RCU Image

### DIFF
--- a/recipes-core/udev/udev-toradex-rules.bbappend
+++ b/recipes-core/udev/udev-toradex-rules.bbappend
@@ -1,9 +1,0 @@
-FILESEXTRAPATHS_prepend := "${THISDIR}/files/:"
-
-# The 99-toradex.rules from apalis-imx8 defines a set of apalis specific SYMLINKs which are not applicable to smartracks.
-# It is pulled in by bitbake because we use the default apalis-imx8 instead of creating a new custom smartracks MACHINE.
-# Hence, this bbappend is added to remove 99-toradex.rules entirely.
-
-do_install_append() {
-    rm -f ${D}${sysconfdir}/udev/rules.d/99-toradex.rules
-}

--- a/recipes-images/images/smartracks-minimal-image.bb
+++ b/recipes-images/images/smartracks-minimal-image.bb
@@ -32,6 +32,8 @@ IMAGE_LINGUAS = "en-us"
 
 CONMANPKGS ?= "connman connman-plugin-loopback connman-plugin-ethernet connman-client"
 
+BAD_RECOMMENDATIONS = "set-hostname udev-toradex-rules"
+
 IMAGE_INSTALL += " \
     packagegroup-boot \
     packagegroup-basic \

--- a/recipes-images/images/smartracks-minimal-image.bb
+++ b/recipes-images/images/smartracks-minimal-image.bb
@@ -32,6 +32,7 @@ IMAGE_LINGUAS = "en-us"
 
 CONMANPKGS ?= "connman connman-plugin-loopback connman-plugin-ethernet connman-client"
 
+# Remove conflicting packages recommended by packagegroup-base-tdx-cli
 BAD_RECOMMENDATIONS = "set-hostname udev-toradex-rules"
 
 IMAGE_INSTALL += " \


### PR DESCRIPTION
Toradex's [packagegroup recipe](https://git.toradex.com/cgit/meta-toradex-demos.git/tree/recipes-images/images/packagegroup-tdx-cli.bb?h=dunfell-5.x.y#n44) installs `set-hostname` and `udev-toradex-rules`. The `set-hostname` package was found to race against `rcu-hostname` to set RCU hostname on first boot.

`udev-toradex-rules` was previously included, but deleted in https://github.com/ni/meta-smartracks/commit/1490ccec2d3e19fb0ff72f4c92c28c146f80bc99. This PR excludes it entirely from RCU image build.

Changes tested on a local build, rootfs tar inspected to confirm exclusion of both packages.