### PR TITLE
Support RCU uSD Port Rework to Apalis SD1

### DIFF
--- a/recipes-core/udev/files/vsftpd-sd.rules
+++ b/recipes-core/udev/files/vsftpd-sd.rules
@@ -1,5 +1,3 @@
 # Configurations to handle starting and stopping vsftpd.service on SD card hotplug
-KERNEL=="mmcblk1", ACTION=="add1"       RUN+="/etc/udev/scripts/vsftpd-sd.sh"
-KERNEL=="mmcblk1", ACTION=="remove1"    RUN+="/etc/udev/scripts/vsftpd-sd.sh"
-KERNEL=="mmcblk2", ACTION=="add2"       RUN+="/etc/udev/scripts/vsftpd-sd.sh"
-KERNEL=="mmcblk2", ACTION=="remove2"    RUN+="/etc/udev/scripts/vsftpd-sd.sh"
+KERNEL=="mmcblk2", ACTION=="add"       RUN+="/etc/udev/scripts/vsftpd-sd.sh"
+KERNEL=="mmcblk2", ACTION=="remove"    RUN+="/etc/udev/scripts/vsftpd-sd.sh"

--- a/recipes-core/udev/files/vsftpd-sd.rules
+++ b/recipes-core/udev/files/vsftpd-sd.rules
@@ -1,3 +1,5 @@
 # Configurations to handle starting and stopping vsftpd.service on SD card hotplug
-KERNEL=="mmcblk1", ACTION=="add"    RUN+="/etc/udev/scripts/vsftpd-sd.sh"
-KERNEL=="mmcblk1", ACTION=="remove"    RUN+="/etc/udev/scripts/vsftpd-sd.sh"
+KERNEL=="mmcblk1", ACTION=="add1"       RUN+="/etc/udev/scripts/vsftpd-sd.sh"
+KERNEL=="mmcblk1", ACTION=="remove1"    RUN+="/etc/udev/scripts/vsftpd-sd.sh"
+KERNEL=="mmcblk2", ACTION=="add2"       RUN+="/etc/udev/scripts/vsftpd-sd.sh"
+KERNEL=="mmcblk2", ACTION=="remove2"    RUN+="/etc/udev/scripts/vsftpd-sd.sh"

--- a/recipes-core/udev/files/vsftpd-sd.sh
+++ b/recipes-core/udev/files/vsftpd-sd.sh
@@ -7,7 +7,7 @@
 
 if [ "$ACTION" = "add" ]; then
 	# Attempt to mount SD card to FTP writable location
-	mount /dev/mmcblk1p1 /var/lib/ftp/upload
+	mount /dev/mmcblk2p1 /var/lib/ftp/upload
 	retcode=$?
 	if [ $retcode -eq 0 ]; then
 		logger "Mount success."

--- a/recipes-kernel/linux/files/imx8-apalis-smartracks.dtsi
+++ b/recipes-kernel/linux/files/imx8-apalis-smartracks.dtsi
@@ -712,10 +712,9 @@
 };
 
 /* RCU's SD1 */
-/* RCU uses Apalis' MMC1 as its SD1, hence the bus-width is reduced to 4 */
+/* RCU uses Apalis' SD1 as its SD1, hence the bus-width is reduced to 4 */
 /* Delete 'no-1-8-v' property to enable UHS-I speed for SD card          */
 &usdhc3 {
-    bus-width = <4>;
     status = "okay";
     /delete-property/ no-1-8-v;
 };

--- a/recipes-kernel/linux/files/imx8-apalis-smartracks.dtsi
+++ b/recipes-kernel/linux/files/imx8-apalis-smartracks.dtsi
@@ -508,29 +508,34 @@
                 IMX8QM_USDHC1_DATA1_CONN_USDHC1_DATA1       0x00000021 /* MXM3 162 */
                 IMX8QM_USDHC1_DATA2_CONN_USDHC1_DATA2       0x00000021 /* MXM3 144 */
                 IMX8QM_USDHC1_DATA3_CONN_USDHC1_DATA3       0x00000021 /* MXM3 146 */
-
+                /* On-module PMIC use */
+                IMX8QM_USDHC1_VSELECT_CONN_USDHC1_VSELECT   0x00000021
             >;
         };
 
         pinctrl_usdhc2_100mhz: usdhc2grp100mhz {
             fsl,pins = <
-                IMX8QM_USDHC1_CLK_CONN_USDHC1_CLK           0x06000041 /* MXM3 154 */
-                IMX8QM_USDHC1_CMD_CONN_USDHC1_CMD           0x00000021 /* MXM3 150 */
-                IMX8QM_USDHC1_DATA0_CONN_USDHC1_DATA0       0x00000021 /* MXM3 160 */
-                IMX8QM_USDHC1_DATA1_CONN_USDHC1_DATA1       0x00000021 /* MXM3 162 */
-                IMX8QM_USDHC1_DATA2_CONN_USDHC1_DATA2       0x00000021 /* MXM3 144 */
-                IMX8QM_USDHC1_DATA3_CONN_USDHC1_DATA3       0x00000021 /* MXM3 146 */
+                IMX8QM_USDHC1_CLK_CONN_USDHC1_CLK           0x06000040 /* MXM3 154 */
+                IMX8QM_USDHC1_CMD_CONN_USDHC1_CMD           0x00000020 /* MXM3 150 */
+                IMX8QM_USDHC1_DATA0_CONN_USDHC1_DATA0       0x00000020 /* MXM3 160 */
+                IMX8QM_USDHC1_DATA1_CONN_USDHC1_DATA1       0x00000020 /* MXM3 162 */
+                IMX8QM_USDHC1_DATA2_CONN_USDHC1_DATA2       0x00000020 /* MXM3 144 */
+                IMX8QM_USDHC1_DATA3_CONN_USDHC1_DATA3       0x00000020 /* MXM3 146 */
+                /* On-module PMIC use */
+                IMX8QM_USDHC1_VSELECT_CONN_USDHC1_VSELECT   0x00000020
             >;
         };
 
         pinctrl_usdhc2_200mhz: usdhc2grp200mhz {
             fsl,pins = <
-                IMX8QM_USDHC1_CLK_CONN_USDHC1_CLK           0x06000041 /* MXM3 154 */
-                IMX8QM_USDHC1_CMD_CONN_USDHC1_CMD           0x00000021 /* MXM3 150 */
-                IMX8QM_USDHC1_DATA0_CONN_USDHC1_DATA0       0x00000021 /* MXM3 160 */
-                IMX8QM_USDHC1_DATA1_CONN_USDHC1_DATA1       0x00000021 /* MXM3 162 */
-                IMX8QM_USDHC1_DATA2_CONN_USDHC1_DATA2       0x00000021 /* MXM3 144 */
-                IMX8QM_USDHC1_DATA3_CONN_USDHC1_DATA3       0x00000021 /* MXM3 146 */
+                IMX8QM_USDHC1_CLK_CONN_USDHC1_CLK           0x06000040 /* MXM3 154 */
+                IMX8QM_USDHC1_CMD_CONN_USDHC1_CMD           0x00000020 /* MXM3 150 */
+                IMX8QM_USDHC1_DATA0_CONN_USDHC1_DATA0       0x00000020 /* MXM3 160 */
+                IMX8QM_USDHC1_DATA1_CONN_USDHC1_DATA1       0x00000020 /* MXM3 162 */
+                IMX8QM_USDHC1_DATA2_CONN_USDHC1_DATA2       0x00000020 /* MXM3 144 */
+                IMX8QM_USDHC1_DATA3_CONN_USDHC1_DATA3       0x00000020 /* MXM3 146 */
+                /* On-module PMIC use */
+                IMX8QM_USDHC1_VSELECT_CONN_USDHC1_VSELECT   0x00000020
             >;
         };
 
@@ -701,16 +706,16 @@
     status = "okay";
 };
 
+/* Apalis MMC1 */
+&usdhc2 {
+    status = "disabled";
+};
+
 /* RCU's SD1 */
 /* RCU uses Apalis' MMC1 as its SD1, hence the bus-width is reduced to 4 */
 /* Delete 'no-1-8-v' property to enable UHS-I speed for SD card          */
-&usdhc2 {
+&usdhc3 {
     bus-width = <4>;
     status = "okay";
     /delete-property/ no-1-8-v;
-};
-
-/* Apalis SD1 */
-&usdhc3 {
-    status = "disabled";
 };


### PR DESCRIPTION
Unconfirmed changes, pending HW team confirmation.

It was recently discovered that the GPIO pins muxed from Apalis MMC1 (DT: usdhc2) were causing the remaining MMC1 pins in use to operate at higher voltage levels (2.1V ~ 2.2V) than expected (1.8V). A rework which routes uSD signals to Apalis SD1 (DT: usdhc3) has been dev tested and is shown to resolve these uSD voltage issues.