### PR TITLE
Add Support for TMP1075 hardware

### DIFF
--- a/recipes-kernel/linux/files/imx8-apalis-smartracks.dtsi
+++ b/recipes-kernel/linux/files/imx8-apalis-smartracks.dtsi
@@ -235,7 +235,7 @@
 
     /* Onboard Temperature Sensor TMP1075 */
     temp_i2c: temp@4F {
-        compatible = "national,lm75";
+        compatible = "ti,tmp1075";
         reg = <0x4F>;
         status = "okay";
     };


### PR DESCRIPTION
Toradex pulled in support for TI TMP1075 in February 2022.
https://git.toradex.com/cgit/linux-toradex.git/commit/?h=toradex_5.4-2.3.x-imx&id=38f1116c5fc7334925a17e5197b349ff16224af5

Support is introduced through the lm75 kernel driver, which we already included as part of our kernel config. All that needs to be done is to set the `compatible` field correctly in DT.