### PR TITLE
Integrate Mender Configuration for RCU Image

### DIFF
--- a/buildconf/bblayers.conf
+++ b/buildconf/bblayers.conf
@@ -29,4 +29,7 @@ BBLAYERS ?= " \
   ${TOPDIR}/../layers/meta-toradex-distro \
   ${TOPDIR}/../layers/meta-yocto/meta-poky \
   ${TOPDIR}/../layers/openembedded-core/meta \
+  
+  ${TOPDIR}/../layers/meta-mender/meta-mender-core \
+  ${TOPDIR}/../layers/meta-mender-community/meta-mender-toradex-nxp \
 "

--- a/buildconf/bblayers.conf
+++ b/buildconf/bblayers.conf
@@ -29,7 +29,7 @@ BBLAYERS ?= " \
   ${TOPDIR}/../layers/meta-toradex-distro \
   ${TOPDIR}/../layers/meta-yocto/meta-poky \
   ${TOPDIR}/../layers/openembedded-core/meta \
-  
+  \
   ${TOPDIR}/../layers/meta-mender/meta-mender-core \
   ${TOPDIR}/../layers/meta-mender-community/meta-mender-toradex-nxp \
 "

--- a/buildconf/export
+++ b/buildconf/export
@@ -18,6 +18,8 @@ echo "To build an image, execute: 'bitbake <supported_image_target>'"
 if [ $FIRST_TIME -eq 1 ]; then
 	mkdir -p conf
 	cp ../layers/meta-smartracks/buildconf/*.conf conf/
+	cat ../layers/meta-mender-community/templates/local.conf.append >> conf/local.conf
+	cat ../layers/meta-mender-community/meta-mender-toradex-nxp/templates/local.conf.append  >> conf/local.conf
 	
 	echo ""
 	$ECHO -e "\033[1mA sample conf/local.conf file has been created"

--- a/buildconf/export
+++ b/buildconf/export
@@ -18,9 +18,7 @@ echo "To build an image, execute: 'bitbake <supported_image_target>'"
 if [ $FIRST_TIME -eq 1 ]; then
 	mkdir -p conf
 	cp ../layers/meta-smartracks/buildconf/*.conf conf/
-	cat ../layers/meta-mender-community/templates/local.conf.append >> ../layers/meta-smartracks/buildconf/local.conf
-	cat ../layers/meta-mender-community/meta-mender-toradex-nxp/templates/local.conf.append  >> ../layers/meta-smartracks/buildconf/local.conf
-
+	
 	echo ""
 	$ECHO -e "\033[1mA sample conf/local.conf file has been created"
 	$ECHO -e "Check and edit the file to adapt to your local needs\033[0m"

--- a/buildconf/export
+++ b/buildconf/export
@@ -18,6 +18,8 @@ echo "To build an image, execute: 'bitbake <supported_image_target>'"
 if [ $FIRST_TIME -eq 1 ]; then
 	mkdir -p conf
 	cp ../layers/meta-smartracks/buildconf/*.conf conf/
+	cat ../layers/meta-mender-community/templates/local.conf.append >> ../layers/meta-smartracks/buildconf/local.conf
+	cat ../layers/meta-mender-community/meta-mender-toradex-nxp/templates/local.conf.append  >> ../layers/meta-smartracks/buildconf/local.conf
 
 	echo ""
 	$ECHO -e "\033[1mA sample conf/local.conf file has been created"

--- a/buildconf/local.conf
+++ b/buildconf/local.conf
@@ -265,5 +265,6 @@ DISTRO = "tdx-xwayland"
 # configurations without copying the machine file.
 include conf/machine/include/${MACHINE}.inc
 
-#TORADEX_BSP_VERSION
+# Toradex BSP version variable consumed by Mender layers to determine correct patch to apply to U-boot
+# Version should be manually updated if newer Toradex BSP versions are supported by Mender
 TORADEX_BSP_VERSION = "toradex-bsp-5.6.0"

--- a/buildconf/local.conf
+++ b/buildconf/local.conf
@@ -264,3 +264,6 @@ DISTRO = "tdx-xwayland"
 # This file does not need to exist, if it does it can be used to influence machine specific
 # configurations without copying the machine file.
 include conf/machine/include/${MACHINE}.inc
+
+#TORADEX_BSP_VERSION
+TORADEX_BSP_VERSION = "toradex-bsp-5.6.0"


### PR DESCRIPTION
The changes are made for including meta-mender and meta-mender-toradex-nxp, as required by the [Toradex Apalis i.MX8](https://hub.mender.io/t/toradex-apalis-i-mx8/4103#:~:text=Download%20mender%20manifest%3A) documentation.
