### PR TITLE
Disable Mender-client running as a system service.

### DIFF
--- a/recipes-core/mender/mender-client_%.bbappend
+++ b/recipes-core/mender/mender-client_%.bbappend
@@ -1,0 +1,1 @@
+SYSTEMD_AUTO_ENABLE = "disable"

--- a/recipes-core/mender/mender-client_%.bbappend
+++ b/recipes-core/mender/mender-client_%.bbappend
@@ -1,4 +1,4 @@
 # Disable Mender to run as a system service automatically at boot as refer to 
 # https://docs.mender.io/system-updates-yocto-project/customize-mender#disabling-mender-as-a-system-service
-# Uncomment below to enable mender running as a systemd service as it has been enabled in meta-mender/meta-mender-core/recipes-mender/mender-client.inc
+# Comment out line below to enable mender running as a systemd service as it has been enabled in meta-mender/meta-mender-core/recipes-mender/mender-client.inc
 SYSTEMD_AUTO_ENABLE = "disable"

--- a/recipes-core/mender/mender-client_%.bbappend
+++ b/recipes-core/mender/mender-client_%.bbappend
@@ -1,1 +1,4 @@
+# Disable Mender to run as a system service automatically at boot as refer to 
+# https://docs.mender.io/system-updates-yocto-project/customize-mender#disabling-mender-as-a-system-service
+# Uncomment below to enable mender running as a systemd service as it has been enabled in meta-mender/meta-mender-core/recipes-mender/mender-client.inc
 SYSTEMD_AUTO_ENABLE = "disable"


### PR DESCRIPTION
To solve the [bug about the mender error messages in Linux message log (/var/log/messages)](https://dev.azure.com/ni/DevCentral/_workitems/edit/2121915). Mender-client is enabled as a system service and periodically checking for updates from a dummy server in the **_meta-mender/meta-mender-core/recipes-mender/mender-client.inc_** file.

The _mender-client_%.bbappend_ file is added to disable the Mender-client running as a system service as refer to the [Customize Mender | Mender documentation](https://docs.mender.io/system-updates-yocto-project/customize-mender#disabling-mender-as-a-system-service).