### PR TITLE
DT: Add RCU carrier CAT24C128 EEPROM

### DIFF
--- a/recipes-kernel/linux/files/imx8-apalis-smartracks.dtsi
+++ b/recipes-kernel/linux/files/imx8-apalis-smartracks.dtsi
@@ -249,6 +249,12 @@
             "IOXPD1_IO5_0", "IOXPD1_IO5_1", "IOXPD1_IO5_2", "IOXPD1_IO5_3", "IOXPD1_IO5_4", "IOXPD1_IO5_5", "IOXPD1_IO5_6", "IOXPD1_IO5_7";
     };
 
+    /* RCU carrier CAT24C128 EEPROM */
+    eeprom: eeprom@50 { 
+        compatible = "atmel,24c128"; 
+        reg = <0x50>;
+    }; 
+
     rtc_i2c: rtc@68 {
         compatible = "dallas,ds3232";
         reg = <0x68>;


### PR DESCRIPTION
RCU carrier EEPROM is located on RCU I2C4, 0x50. Adding to device tree so that instantiation of EEPROM can take place during boot. RCU carrier EEPROM support should be present as it is part of 140 FVT requirement.

Supporting documents:

[ATE Core Test Plans](https://nio365.sharepoint.com/:x:/r/sites/SmartRack/_layouts/15/Doc.aspx?sourcedoc=%7B9F9DEE91-D35B-4BFC-A4C2-E05B6710ED86%7D&file=ATE%20Core%20Test%20Plans.xlsx&wdOrigin=TEAMS-WEB.p2p.bim&action=default&mobileredirect=true)
[CCA EEPROM Register Map](https://nio365.sharepoint.com/:x:/r/sites/SmartRack/_layouts/15/Doc.aspx?sourcedoc=%7B2B9DAAC3-6DF8-44D9-A3C7-B64C3E822266%7D&file=CCA%20EEPROM%20Register%20Map.xlsx&wdOrigin=TEAMS-WEB.p2p.bim&action=default&mobileredirect=true)