### PR TITLE
rcu-hostname: Bump implementation to latest

### DIFF
--- a/recipes-core/rcu-hostname/files/rcu-hostname.service
+++ b/recipes-core/rcu-hostname/files/rcu-hostname.service
@@ -1,9 +1,7 @@
 [Unit]
-ConditionPathExists=|!/etc/hostname
+ConditionFileNotEmpty=|!/etc/hostname
 Wants=network-pre.target
 Before=network-pre.target
-# Make sure that ni-smartracks hostname is set before avahi-daemon registers hostname to DNS
-Before=avahi-daemon.service
 After=local-fs.target
 After=sys-subsystem-net-devices-eth0.device
 

--- a/recipes-core/rcu-hostname/files/rcu-hostname.service
+++ b/recipes-core/rcu-hostname/files/rcu-hostname.service
@@ -1,5 +1,5 @@
 [Unit]
-#ConditionPathExists=|!/etc/hostname
+ConditionPathExists=|!/etc/hostname
 Wants=network-pre.target
 Before=network-pre.target
 # Make sure that ni-smartracks hostname is set before avahi-daemon registers hostname to DNS


### PR DESCRIPTION
PR makes script which sets RCU hostname runs only if hostname is not already set, in anticipation of allowing user-defined hostname to persist across reboots ([US 1233879](https://dev.azure.com/ni/DevCentral/_workitems/edit/1233879)). The workaround which forces the service to run before avahi-daemon is also removed, since the original issue was caused by race condition involving [set-hostname](https://git.toradex.com/cgit/meta-toradex-bsp-common.git/tree/recipes-core/set-hostname/files/set-hostname.service?h=dunfell-5.x.y), which was removed in https://github.com/ni/meta-smartracks/commit/e24df282fa1f5dda97ef96b8d4db4dbf56101a47.