### PR TITLE
Update EMC2303 config as advised by ME

### DIFF
--- a/recipes-kernel/linux/files/0001-hwmon-add-support-for-SMSC-EMC2303.patch
+++ b/recipes-kernel/linux/files/0001-hwmon-add-support-for-SMSC-EMC2303.patch
@@ -156,7 +156,7 @@ index 00000000..b2ae311
 + * 3:2      GINx[1:0]    01 = 2x Integral Gain.
 + * 1:0      GPRx[1:0]    01 = 2x Proportional Gain.
 + */
-+#define REG_GAIN_VALUE   0x15
++#define REG_GAIN_VALUE   0x14
 +
 +/* Fan Spin Up Configuration Registers at 36H, 46H and 56H (Section 6.17)
 + * bit      Field        Value
@@ -172,7 +172,7 @@ index 00000000..b2ae311
 + * 7:6      -            -
 + * 5:0      FxMS[5:0]    00 0101 = Fan Drive Max Step size is 5.
 + */
-+#define REG_FAN_MAX_STEP_VALUE   0x05
++#define REG_FAN_MAX_STEP_VALUE   0x01
 +
 +/* Fan Minimum Drive Register at 38H, 48H and 58H (Section 6.19)
 + * bit      Field        Value
@@ -801,4 +801,3 @@ index 00000000..b2ae311
 +MODULE_LICENSE("GPL");
 -- 
 2.7.4
-


### PR DESCRIPTION
Addressing [US 2053703](https://dev.azure.com/ni/DevCentral/_workitems/edit/2053703). Quoting Ching Guan:

> We only change the following registers based on current released image: 
> REG_GAIN_VALUE (35h, 45h, 55h) 0x15 -> 0x14
> REG_FAN_MAX_STEP_VALUE (37h, 47h, 57h) 0x05 -> 0x01