### PR TITLE
Customize RCU IP Settings via systemd-networkd Interface

### DIFF
--- a/recipes-core/systemd/files/eth0.network
+++ b/recipes-core/systemd/files/eth0.network
@@ -1,0 +1,5 @@
+[Match]
+Name=eth0
+
+[Network]
+DHCP=ipv4

--- a/recipes-core/systemd/files/eth1.network
+++ b/recipes-core/systemd/files/eth1.network
@@ -1,0 +1,7 @@
+[Match]
+Name=eth1
+
+[Network]
+Address=10.1.1.20/24
+Gateway=10.1.1.1
+DNS=10.1.1.1

--- a/recipes-core/systemd/systemd_%.bbappend
+++ b/recipes-core/systemd/systemd_%.bbappend
@@ -1,0 +1,29 @@
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+SRC_URI += " \
+    file://eth0.network \
+    file://eth1.network \
+"
+
+PACKAGECONFIG_append = " networkd"
+
+do_install_append() {
+
+    # We install actual eth0 and eth1 network configuration files into persistent data partition
+    # allowing these settings to persist across Mender updates
+    install -d ${D}/data/systemd/network/
+    install -d ${D}/etc/systemd/network/
+    install -m 0644 ${WORKDIR}/eth0.network ${D}/data/systemd/network
+    install -m 0644 ${WORKDIR}/eth1.network ${D}/data/systemd/network
+
+    # Create symlinks in /etc/systemd/network which point to those files in /data
+    ln -s -r ${D}/data/systemd/network/eth0.network ${D}/etc/systemd/network/eth0.network
+    ln -s -r ${D}/data/systemd/network/eth1.network ${D}/etc/systemd/network/eth1.network
+}
+
+FILES_${PN} += " \
+    /data/systemd/network/* \
+"

--- a/recipes-images/images/smartracks-minimal-image.bb
+++ b/recipes-images/images/smartracks-minimal-image.bb
@@ -30,8 +30,6 @@ ROOTFS_POSTPROCESS_COMMAND += " add_rootfs_version;"
 IMAGE_LINGUAS = "en-us"
 #IMAGE_LINGUAS = "de-de fr-fr en-gb en-us pt-br es-es kn-in ml-in ta-in"
 
-CONMANPKGS ?= "connman connman-plugin-loopback connman-plugin-ethernet connman-client"
-
 # Remove conflicting packages recommended by packagegroup-base-tdx-cli
 BAD_RECOMMENDATIONS = "set-hostname udev-toradex-rules"
 
@@ -42,7 +40,6 @@ IMAGE_INSTALL += " \
     packagegroup-machine-tdx-cli \
     packagegroup-base-ni-cli \
     udev-extraconf \
-    ${CONMANPKGS} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'timestamp-service systemd-analyze', '', d)} \
 "
 


### PR DESCRIPTION
PR to address [US 2195506](https://dev.azure.com/ni/DevCentral/_workitems/edit/2195506). Changes made to append eth0 and eth1 network configuration as part of systemd installation. After some consideration, these network configuration files will be installed in the persistent data partition (/data/systemd/network) - Symlinks to these files located in /data will be created where systemd-networkd expects them to be (/etc/systemd/network). 

Testing done on RCU + fanout board setup, eth0 works properly after changes were made. 