### PR TITLE
Add VERSION variable as part of RCU IMAGE_NAME

### DIFF
--- a/recipes-images/images/smartracks-minimal-image.bb
+++ b/recipes-images/images/smartracks-minimal-image.bb
@@ -8,7 +8,8 @@ LICENSE = "MIT"
 #Prefix to the resulting deployable tarball name
 export IMAGE_BASENAME = "RCU-Image"
 MACHINE_NAME = "NI-ATE-Core"
-IMAGE_NAME = "${MACHINE_NAME}_${IMAGE_BASENAME}"
+VERSION = "custom"
+IMAGE_NAME = "${MACHINE_NAME}_${IMAGE_BASENAME}_${VERSION}"
 
 # Copy Licenses to image /usr/share/common-license
 COPY_LIC_MANIFEST ?= "1"


### PR DESCRIPTION
Initial work to address [US 2235044](https://dev.azure.com/ni/DevCentral/_workitems/edit/2235044).

The IMAGE_NAME variable is is consumed by [image_type_mender_tezi.bbclass](https://github.com/mendersoftware/meta-mender-community/blob/dunfell/meta-mender-toradex-nxp/classes/image_type_mender_tezi.bbclass#L167) and other Mender recipes to produce the Mender images. Having the image version string be appended to IMAGE_NAME will allow the images to be built with the version string as part of the image build export filename.

The "custom" value is a placeholder for the actual version string, which will be filled in by the rcu-image build pipeline, e.g.,

sed -i 's/VERSION = "custom"/VERSION = '$(version)'/g' /path/to/smartracks-minimal-image.bb