### PR TITLE
Specify Onboard ADS7830 in Device Tree

### DIFF
--- a/recipes-kernel/linux/files/imx8-apalis-smartracks.dtsi
+++ b/recipes-kernel/linux/files/imx8-apalis-smartracks.dtsi
@@ -277,6 +277,24 @@
         compatible = "dallas,ds3232";
         reg = <0x68>;
     };
+    
+    /* Onboard ADC ADS7830 at 0x48 */
+    ads7830_1: ads@48 {
+        compatible = "ti,ads7830";
+        reg = <0x48>;
+    };
+
+    /* Onboard ADC ADS7830 at 0x4a */
+    ads7830_2: ads@4a {
+        compatible = "ti,ads7830";
+        reg = <0x4a>;
+    };
+
+    /* Onboard ADC ADS7830 at 0x4b */
+    ads7830_3: ads@4b {
+        compatible = "ti,ads7830";
+        reg = <0x4b>;
+    };
 
     /* Onboard Temperature Sensor TMP1075 */
     temp_i2c: temp@4F {


### PR DESCRIPTION
PR to address [US 2244093](https://dev.azure.com/ni/DevCentral/_workitems/edit/2244093).

ADS7830 located on RCU I2C4, 0x48, 0x4a, 0x4b. ADC configuration requested by HW team is as follows:

- Single Ended Input
- Internal Voltage Reference ON
- A/D Converter ON

With reference to [Documentation/devicetree/bindings/hwmon/ads7828.txt](https://git.toradex.com/cgit/linux-toradex.git/tree/Documentation/devicetree/bindings/hwmon/ads7828.txt?h=toradex_5.4-2.3.x-imx), This translates to not specifying `ti,differential-input` and omitting `vref-supply` specification. 