### PR TITLE
Install jq as part of smartracks-minimal-image

### DIFF
--- a/recipes-images/images/packagegroup-ni-cli.bb
+++ b/recipes-images/images/packagegroup-ni-cli.bb
@@ -26,6 +26,7 @@ RRECOMMENDS_packagegroup-base-ni-cli = "\
     keyutils \
     cifs-utils \
     rcu-config \
+    jq \
 "
 
 SUMMARY_packagegroup-devel-ni-cli = "Tools useful during SmartRacks RCU development"


### PR DESCRIPTION
Pulling jq into RCU image, as required in [_Rcu_Hostname.md](https://dev.azure.com/ni/DevCentral/_git/ni-central?path=/docs/specs/chassis_controller/SmartRacks/RCU_Software/_Rcu_Hostname.md).

Installed and dev tested jq on RCU + fanout board. Command works as expected on mfgconfig.json.