### PR TITLE
Update DT model attribute

### DIFF
--- a/recipes-kernel/linux/files/imx8-apalis-smartracks.dts
+++ b/recipes-kernel/linux/files/imx8-apalis-smartracks.dts
@@ -4,7 +4,7 @@
 #include "imx8-apalis-smartracks.dtsi"
 
 / {
-	model = "Toradex Apalis iMX8QP V1.1 on Smartracks RCU";
+	model = "Apalis iMX8QP 2GB V1.1C";
 	compatible = "toradex,apalis-imx8qp-v1.1-eval",
 		     "toradex,apalis-imx8qp-v1.1",
 		     "toradex,apalis-imx8-v1.1",


### PR DESCRIPTION
SW test has plans to populate RCU description field within RCU Carrier EEPROM using information that can be programmatically obtained on the RCU itself. A decision has been made to utilize the `model` property for holding the RCU description string to be written by test engineer to the EEPROM. See [CCA EEPROM Register Map](https://nio365.sharepoint.com/:x:/r/sites/SmartRack/Shared%20Documents/7_General/1_CCA/CCA%20EEPROM%20Register%20Map.xlsx?d=w2b9daac36df844d9a3c7b64c3e822266&csf=1&web=1&e=NLJg29&nav=MTBfezgzYTYwZmNmLWY4NjUtNGQxMy1hNTIxLWFjMTkyYWE5YzI4ZX1fe0ZBOEI2NEEzLUVEODQtNDkxRS04Rjk3LTM4NjQ0MzM0NkNENn0).

The `model` property in DT can be obtained by running the following command on the RCU at runtime:

```sh
cat /proc/device-tree/model
```