### PR TITLE
Enlarge RCU Image Root Filesystem Size

### DIFF
--- a/buildconf/export
+++ b/buildconf/export
@@ -20,6 +20,7 @@ if [ $FIRST_TIME -eq 1 ]; then
 	cp ../layers/meta-smartracks/buildconf/*.conf conf/
 	cat ../layers/meta-mender-community/templates/local.conf.append >> conf/local.conf
 	cat ../layers/meta-mender-community/meta-mender-toradex-nxp/templates/local.conf.append  >> conf/local.conf
+	sed -i 's/MENDER_STORAGE_TOTAL_SIZE_MB_apalis-imx8 = "2048"/MENDER_STORAGE_TOTAL_SIZE_MB_apalis-imx8 = "4096"/g' conf/local.conf
 	
 	echo ""
 	$ECHO -e "\033[1mA sample conf/local.conf file has been created"


### PR DESCRIPTION
As described in [_Rcu_Image.md](https://dev.azure.com/ni/DevCentral/_git/ni-central?path=/docs/specs/chassis_controller/SmartRacks/RCU_Software/_Rcu_Image.md&_a=preview&anchor=primary-storage-partition-and-directory-layout), RCU Image A/B partition size should be total 4GB.

Since MENDER_STORAGE_TOTAL_SIZE_MB_apalis-imx8 is defined in Mender Yocto layers, changing it there is not feasible. Instead, the value is altered in local.conf after Mender configuration is copied into local.conf.

After making this change, the new image with enlarged rootfs needs to be flashed using TEZI, as Mender cannot flash images with larger partition size compared to what is available on the device. See [link](https://hub.mender.io/t/no-space-left-on-device/310). Preferably once this change is made, we will make an announcement in Teams to get everyone to flash the new image with TEZI. 