### PR TITLE
Persist RCU user credentials across Mender updates

### DIFF
--- a/recipes-images/images/packagegroup-ni-cli.bb
+++ b/recipes-images/images/packagegroup-ni-cli.bb
@@ -22,6 +22,7 @@ RRECOMMENDS_packagegroup-base-ni-cli = "\
     coreutils \
     rcu-service \
     rcu-image-version \
+    rcu-state-scripts \
     udev-ni-rules \
     keyutils \
     cifs-utils \

--- a/recipes-mender/rcu-state-scripts/files/retain-credentials
+++ b/recipes-mender/rcu-state-scripts/files/retain-credentials
@@ -40,6 +40,7 @@ if [ -d /mnt/etc ]; then
     echo "Copied user and group credentials to new root partition" >&2
 else
     echo "Failed to find /etc on new root partition" >&2
+    umount $newroot
     exit 1
 fi
 

--- a/recipes-mender/rcu-state-scripts/files/retain-credentials
+++ b/recipes-mender/rcu-state-scripts/files/retain-credentials
@@ -5,13 +5,15 @@
 
 echo "$(mender show-artifact): Running $(basename "$0")" >&2
 
-# Testing 
+# Check if fw_printenv command is available
 if [ ! -x /usr/bin/fw_printenv ]; then
     exit 1
 fi
 
+# Check current rootfs partition
 current=$(/usr/bin/fw_printenv mender_boot_part | awk -F = '{ print $2 }')
 
+# Deduce target rootfs partition based on current rootfs partition number
 if [ $current = "2" ]; then
     newroot=/dev/mmcblk0p3
 elif [ $current = "3" ]; then
@@ -35,11 +37,10 @@ if [ -d /mnt/etc ]; then
     cp /etc/shadow /mnt/etc/shadow
     cp /etc/group /mnt/etc/group
     cp /etc/gshadow /mnt/etc/gshadow
-    echo "Copied /etc/systemd/network to new root partition" >&2
+    echo "Copied user and group credentials to new root partition" >&2
 else
     echo "Failed to find /etc on new root partition" >&2
     exit 1
 fi
 
 umount $newroot
-

--- a/recipes-mender/rcu-state-scripts/files/retain-credentials
+++ b/recipes-mender/rcu-state-scripts/files/retain-credentials
@@ -1,0 +1,45 @@
+#!/bin/sh
+#
+# Retain RCU user credentials from the current root
+#
+
+echo "$(mender show-artifact): Running $(basename "$0")" >&2
+
+# Testing 
+if [ ! -x /usr/bin/fw_printenv ]; then
+    exit 1
+fi
+
+current=$(/usr/bin/fw_printenv mender_boot_part | awk -F = '{ print $2 }')
+
+if [ $current = "2" ]; then
+    newroot=/dev/mmcblk0p3
+elif [ $current = "3" ]; then
+    newroot=/dev/mmcblk0p2
+else
+    echo "Unexpected current root: $current" >&2
+    exit 1
+fi
+
+mount $newroot /mnt
+
+if [ $? -ne 0 ]; then
+    echo "Failed to mount $newroot" >&2
+    exit 1
+fi
+
+sleep 2
+
+if [ -d /mnt/etc ]; then
+    cp /etc/passwd /mnt/etc/passwd
+    cp /etc/shadow /mnt/etc/shadow
+    cp /etc/group /mnt/etc/group
+    cp /etc/gshadow /mnt/etc/gshadow
+    echo "Copied /etc/systemd/network to new root partition" >&2
+else
+    echo "Failed to find /etc on new root partition" >&2
+    exit 1
+fi
+
+umount $newroot
+

--- a/recipes-mender/rcu-state-scripts/rcu-state-scripts_1.0.bb
+++ b/recipes-mender/rcu-state-scripts/rcu-state-scripts_1.0.bb
@@ -1,0 +1,12 @@
+SUMMARY = "RCU Mender State Scripts"
+DESCRIPTION = "Recipe to install RCU Mender State Scripts"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+SRC_URI = "file://retain-credentials "
+
+inherit mender-state-scripts
+
+do_compile() {
+    cp ${WORKDIR}/retain-credentials ${MENDER_STATE_SCRIPTS_DIR}/ArtifactInstall_Enter_00
+}


### PR DESCRIPTION
PR to address [US 2172148](https://dev.azure.com/ni/DevCentral/_workitems/edit/2172148).

Mender state script content largely leveraged from examples provided here:
https://github.com/mendersoftware/mender/tree/master/examples/state-scripts

Technique:
Since symlinking /etc/passwd, /etc/shadow, etc in /data is [discouraged](https://serverfault.com/questions/491033/), the only solution left is to manually copy them into the new rootfs partition after the new RCU image has been written to the target partition by Mender. To achieve this, [state scripts](https://docs.mender.io/artifact-creation/state-scripts) are utilized to mount the target partition and copy over the relevant credential files.

Reference:
https://hub.mender.io/t/maintaining-linux-unique-password/3244
https://hub.mender.io/t/rootfs-update-module-keep-existing-file-from-active-partition-in-new-partition/2465
https://learning.lpi.org/en/learning-materials/010-160/5/5.2/5.2_01/

Testing:
Solution verified on RCU + fanout board. Root account password modified using `passwd` command. Modified password still applies after Mender update to new RCU image containing the added state script.