### PR TITLE
Changed owner of log folder to ftp user.

### DIFF
--- a/recipes-core/udev/files/vsftpd-sd.sh
+++ b/recipes-core/udev/files/vsftpd-sd.sh
@@ -7,7 +7,9 @@
 
 if [ "$ACTION" = "add" ]; then
 	# Attempt to mount SD card to FTP writable location
-	mount /dev/mmcblk1p1 /var/lib/ftp/upload
+	ftp_uid=$(id -u ftp)
+	ftp_gid=$(id -g ftp)
+	mount -o uid=${ftp_uid},gid=${ftp_gid} /dev/mmcblk1p1 /var/lib/ftp/upload
 	retcode=$?
 	if [ $retcode -eq 0 ]; then
 		logger "Mount success."


### PR DESCRIPTION
BUG: [155682 RCU FTP service no upload permissions](https://dev.azure.com/ni/DevCentral/_workitems/edit/1556882)

Problem Statement:
FTP user could not modify/edit files in /var/lib/ftp/upload/log, this was because this folder was mount as root.

Solution:
Change the User ID and Group ID to FTP user ID during mount.

Testing.
FTP user is able to edit/modify/add/delete files in the log folder.
![image](https://user-images.githubusercontent.com/103085603/219616554-fdf13831-c2e8-4df3-ab1b-0420613809e5.png)

