### PR TITLE
Add script to reset RCU IP configuration

### DIFF
--- a/recipes-core/systemd/files/eth1.network
+++ b/recipes-core/systemd/files/eth1.network
@@ -3,5 +3,3 @@ Name=eth1
 
 [Network]
 Address=10.1.1.20/24
-Gateway=10.1.1.1
-DNS=10.1.1.1

--- a/recipes-core/systemd/files/reset-ip-config
+++ b/recipes-core/systemd/files/reset-ip-config
@@ -18,7 +18,6 @@ DHCP=ipv4
 " > /data/systemd/network/eth0.network
 
 echo "
-
 [Match]
 Name=eth1
 

--- a/recipes-core/systemd/files/reset-ip-config
+++ b/recipes-core/systemd/files/reset-ip-config
@@ -23,8 +23,6 @@ Name=eth1
 
 [Network]
 Address=10.1.1.20/24
-Gateway=10.1.1.1
-DNS=10.1.1.1
 " > /data/systemd/network/eth1.network
 
 sync

--- a/recipes-core/systemd/files/reset-ip-config
+++ b/recipes-core/systemd/files/reset-ip-config
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+# Script which resets RCU IP address configuration for both eth0 and eth1
+# This is done by
+# 1) Removing eth0 and eth1 network configuration files from /data/systemd/network
+# 2) Recreating those files with default eth0 and eth1 configuration
+# 3) Restarting systemd-networkd for changes to take effect
+
+rm /data/systemd/network/eth0.network
+rm /data/systemd/network/eth1.network
+
+echo "
+[Match]
+Name=eth0
+
+[Network]
+DHCP=ipv4
+" > /data/systemd/network/eth0.network
+
+echo "
+
+[Match]
+Name=eth1
+
+[Network]
+Address=10.1.1.20/24
+Gateway=10.1.1.1
+DNS=10.1.1.1
+" > /data/systemd/network/eth1.network
+
+sync
+
+systemctl restart systemd-networkd

--- a/recipes-core/systemd/systemd_%.bbappend
+++ b/recipes-core/systemd/systemd_%.bbappend
@@ -14,16 +14,19 @@ do_install_append() {
 
     # We install actual eth0 and eth1 network configuration files into persistent data partition
     # allowing these settings to persist across Mender updates
+    install -d ${D}${bindir}
     install -d ${D}/data/systemd/network/
-    install -d ${D}/etc/systemd/network/
+    install -d ${D}/${systemd_unitdir}/network/
+    install -m 0755 ${WORKDIR}/reset-ip-config ${D}${bindir}
     install -m 0644 ${WORKDIR}/eth0.network ${D}/data/systemd/network
     install -m 0644 ${WORKDIR}/eth1.network ${D}/data/systemd/network
 
     # Create symlinks in /etc/systemd/network which point to those files in /data
-    ln -s -r ${D}/data/systemd/network/eth0.network ${D}/etc/systemd/network/eth0.network
-    ln -s -r ${D}/data/systemd/network/eth1.network ${D}/etc/systemd/network/eth1.network
+    ln -s -r ${D}/data/systemd/network/eth0.network ${D}/${systemd_unitdir}/network/eth0.network
+    ln -s -r ${D}/data/systemd/network/eth1.network ${D}/${systemd_unitdir}/network/eth1.network
 }
 
 FILES_${PN} += " \
+    ${bindir} \
     /data/systemd/network/* \
 "

--- a/recipes-core/systemd/systemd_%.bbappend
+++ b/recipes-core/systemd/systemd_%.bbappend
@@ -16,14 +16,14 @@ do_install_append() {
     # allowing these settings to persist across Mender updates
     install -d ${D}${bindir}
     install -d ${D}/data/systemd/network/
-    install -d ${D}/${systemd_unitdir}/network/
+    install -d ${D}/etc/systemd/network/
     install -m 0755 ${WORKDIR}/reset-ip-config ${D}${bindir}
     install -m 0644 ${WORKDIR}/eth0.network ${D}/data/systemd/network
     install -m 0644 ${WORKDIR}/eth1.network ${D}/data/systemd/network
 
     # Create symlinks in /etc/systemd/network which point to those files in /data
-    ln -s -r ${D}/data/systemd/network/eth0.network ${D}/${systemd_unitdir}/network/eth0.network
-    ln -s -r ${D}/data/systemd/network/eth1.network ${D}/${systemd_unitdir}/network/eth1.network
+    ln -s -r ${D}/data/systemd/network/eth0.network ${D}/etc/systemd/network/eth0.network
+    ln -s -r ${D}/data/systemd/network/eth1.network ${D}/etc/systemd/network/eth1.network
 }
 
 FILES_${PN} += " \


### PR DESCRIPTION
Add a simple script to reset RCU IP configuration to default configuration. Useful to SW test and can potentially be leveraged by rcu-service when implementing IP reset button. 