### PR TITLE
Disable SSH server by default and persist setting across updates

### DIFF
--- a/recipes-core/dropbear/dropbear_%.bbappend
+++ b/recipes-core/dropbear/dropbear_%.bbappend
@@ -1,0 +1,2 @@
+# Disable Dropbear SSH server by default
+SYSTEMD_AUTO_ENABLE = "disable"

--- a/recipes-mender/rcu-state-scripts/files/retain-ssh-service-status
+++ b/recipes-mender/rcu-state-scripts/files/retain-ssh-service-status
@@ -1,0 +1,42 @@
+#!/bin/sh
+#
+# Retain Dropbear SSH server service status
+#
+
+echo "$(mender show-artifact): Running $(basename "$0")" >&2
+
+# Check if fw_printenv command is available
+if [ ! -x /usr/bin/fw_printenv ]; then
+    exit 1
+fi
+
+# Check current rootfs partition
+current=$(/usr/bin/fw_printenv mender_boot_part | awk -F = '{ print $2 }')
+
+# Deduce target rootfs partition based on current rootfs partition number
+if [ $current = "2" ]; then
+    newroot=/dev/mmcblk0p3
+elif [ $current = "3" ]; then
+    newroot=/dev/mmcblk0p2
+else
+    echo "Unexpected current root: $current" >&2
+    exit 1
+fi
+
+mount $newroot /mnt
+
+if [ $? -ne 0 ]; then
+    echo "Failed to mount $newroot" >&2
+    exit 1
+fi
+
+sleep 2
+
+# Check that Dropbear socket symlink was created
+# This indicates that Dropbear SSH server was enabled 
+if [ -f /etc/systemd/system/sockets.target.wants/dropbear.socket  ]; then
+    cp -P /etc/systemd/system/sockets.target.wants/dropbear.socket  /mnt/etc/systemd/system/sockets.target.wants/dropbear.socket 
+    echo "Enabled Dropbear SSH server on new root partition" >&2
+fi
+
+umount $newroot

--- a/recipes-mender/rcu-state-scripts/rcu-state-scripts_1.0.bb
+++ b/recipes-mender/rcu-state-scripts/rcu-state-scripts_1.0.bb
@@ -3,10 +3,14 @@ DESCRIPTION = "Recipe to install RCU Mender State Scripts"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 
-SRC_URI = "file://retain-credentials "
+SRC_URI = " \
+    file://retain-credentials \
+    file://retain-ssh-service-status \
+"
 
 inherit mender-state-scripts
 
 do_compile() {
     cp ${WORKDIR}/retain-credentials ${MENDER_STATE_SCRIPTS_DIR}/ArtifactInstall_Enter_00
+    cp ${WORKDIR}/retain-ssh-service-status ${MENDER_STATE_SCRIPTS_DIR}/ArtifactInstall_Enter_01
 }


### PR DESCRIPTION
PR to disable dropbear SSH server from running by default on RCU. Also added mender state scripts which will persist SSH server availability across mender updates. This allows the following behavior to take place:

1. If SSH server is currently enabled on RCU, mender update will not disable SSH server.
2. If SSH server is already disabled on RCU, SSH server remains disabled after mender update.
3. Flashing RCU via TEZI always disables RCU SSH server by default. 

Testing done on local RCU setup to verify the behavior stated above.