### PR TITLE
Hotfix to get IP reset script to build correctly 

### DIFF
--- a/recipes-core/systemd/systemd_%.bbappend
+++ b/recipes-core/systemd/systemd_%.bbappend
@@ -6,6 +6,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 SRC_URI += " \
     file://eth0.network \
     file://eth1.network \
+    file://reset-ip-config \
 "
 
 PACKAGECONFIG_append = " networkd"


### PR DESCRIPTION
An oversight of https://github.com/ni/meta-smartracks/pull/92 where reset-ip-config script was not added to SRC_URI.

Tested on local build environment.