### PR TITLE
Prepare rcu-service firmware and tmp directories

### DIFF
--- a/recipes-ni/proprietary/rcu-service/rcu-service_1.0.bb
+++ b/recipes-ni/proprietary/rcu-service/rcu-service_1.0.bb
@@ -13,5 +13,6 @@ do_install() {
          install -m 0755 rcu-service ${D}${bindir}
          install -d ${D}/${systemd_unitdir}/system
          install -m 0644 ${S}/rcu-service.service ${D}/${systemd_unitdir}/system
+         install -d ${D}/data/rcu-service/tmp
+         install -d ${D}/data/rcu-service/firmware
 }
-


### PR DESCRIPTION
Additions to rcu-service recipe to create /data/rcu-service/tmp and /data/rcu-service/firmware directories as described in [_Rcu_Image.md](https://dev.azure.com/ni/DevCentral/_git/ni-central?path=/docs/specs/chassis_controller/SmartRacks/RCU_Software/_Rcu_Image.md&_a=preview).