### PR TITLE
Test using private key stored as secret

### DIFF
--- a/recipes-ni/proprietary/rcu-service/rcu-service_1.0.bb
+++ b/recipes-ni/proprietary/rcu-service/rcu-service_1.0.bb
@@ -9,7 +9,7 @@ SYSTEMD_AUTO_ENABLE = "enable"
 SYSTEMD_SERVICE_${PN} = "rcu-service.service"
 
 do_configure_append() {
-    echo $NI_ATE_CORE_PRIVATE_KEY > ${S}/certs/ni_ate_core_private.key
+         echo $NI_ATE_CORE_PRIVATE_KEY > ${S}/certs/ni_ate_core_private.key
 }
 
 do_install() {

--- a/recipes-ni/proprietary/rcu-service/rcu-service_1.0.bb
+++ b/recipes-ni/proprietary/rcu-service/rcu-service_1.0.bb
@@ -8,7 +8,9 @@ inherit systemd
 SYSTEMD_AUTO_ENABLE = "enable"
 SYSTEMD_SERVICE_${PN} = "rcu-service.service"
 
-echo $NI_ATE_CORE_PRIVATE_KEY > ${S}/certs/ni_ate_core_private.key
+do_configure_append() {
+    echo $NI_ATE_CORE_PRIVATE_KEY > ${S}/certs/ni_ate_core_private.key
+}
 
 do_install() {
          install -d ${D}${bindir}

--- a/recipes-ni/proprietary/rcu-service/rcu-service_1.0.bb
+++ b/recipes-ni/proprietary/rcu-service/rcu-service_1.0.bb
@@ -8,6 +8,8 @@ inherit systemd
 SYSTEMD_AUTO_ENABLE = "enable"
 SYSTEMD_SERVICE_${PN} = "rcu-service.service"
 
+echo $NI_ATE_CORE_PRIVATE_KEY > ${S}/certs/ni_ate_core_private.key
+
 do_install() {
          install -d ${D}${bindir}
          install -m 0755 rcu-service ${D}${bindir}
@@ -15,4 +17,6 @@ do_install() {
          install -m 0644 ${S}/rcu-service.service ${D}/${systemd_unitdir}/system
          install -d ${D}/data/rcu-service/tmp
          install -d ${D}/data/rcu-service/firmware
+         install -d ${D}/${sysconfdir}/ssl/private
+         install -m 0640 ${S}/certs/ni_ate_core_private.key ${D}/${sysconfdir}/ssl/private
 }


### PR DESCRIPTION
## Justification
This is to serve as a test to prove that we can reference github secrets into files, that will then be packaged into mender image. If this works, it may be how we inject the gRPC TLS private key into RCU image.

## Changes
Echo secret private key into key file before packaging it into mender image.
Add steps to install private key onto RCU.