### PR TITLE
Move installation of tmp and firmware directories to rcu-config

### DIFF
--- a/recipes-core/rcu-config/rcu-config.bb
+++ b/recipes-core/rcu-config/rcu-config.bb
@@ -5,10 +5,12 @@ SRC_URI = "\
     file://mfgconfig.json \
 "
 
-FILES_${PN} += " /data/rcu-service/config/* "
+FILES_${PN} += "/data/rcu-service/* "
 
 do_install () {
     install -d ${D}/data/rcu-service/config
+    install -d ${D}/data/rcu-service/tmp
+    install -d ${D}/data/rcu-service/firmware
     install -m 0644 ${WORKDIR}/mfgconfig.json ${D}/data/rcu-service/config
 }
 

--- a/recipes-ni/proprietary/rcu-service/rcu-service_1.0.bb
+++ b/recipes-ni/proprietary/rcu-service/rcu-service_1.0.bb
@@ -17,8 +17,6 @@ do_install() {
          install -m 0755 rcu-service ${D}${bindir}
          install -d ${D}/${systemd_unitdir}/system
          install -m 0644 ${S}/rcu-service.service ${D}/${systemd_unitdir}/system
-         install -d ${D}/data/rcu-service/tmp
-         install -d ${D}/data/rcu-service/firmware
          install -d ${D}/${sysconfdir}/ssl/private
          install -m 0640 ${S}/certs/ni_ate_core_private.key ${D}/${sysconfdir}/ssl/private
 }


### PR DESCRIPTION
Builds were failing due to lack of FILES_${PN} += statement in rcu-service recipe for installing to /data. It struck me that these instructions would make more sense to live in rcu-config recipe, which already installs files and directories to /data.

Changes tested on local build machine.  