### PR TITLE
mkdir before adding key

### DIFF
--- a/recipes-ni/proprietary/rcu-service/rcu-service_1.0.bb
+++ b/recipes-ni/proprietary/rcu-service/rcu-service_1.0.bb
@@ -9,6 +9,7 @@ SYSTEMD_AUTO_ENABLE = "enable"
 SYSTEMD_SERVICE_${PN} = "rcu-service.service"
 
 do_configure_append() {
+         mkdir -p ${S}/certs
          echo $NI_ATE_CORE_PRIVATE_KEY > ${S}/certs/ni_ate_core_private.key
 }
 


### PR DESCRIPTION
## Justification
Changes implemented in https://github.com/ni/meta-smartracks/pull/96 did not work, suspect it is due to /certs/ directory is not present. Added mkdir to fix it.

## Changes
Added mkdir to create /certs directory if not exists before copying private key to said path