### PR TITLE
Remove do_configure_append

### DIFF
--- a/recipes-ni/proprietary/rcu-service/rcu-service_1.0.bb
+++ b/recipes-ni/proprietary/rcu-service/rcu-service_1.0.bb
@@ -8,11 +8,6 @@ inherit systemd
 SYSTEMD_AUTO_ENABLE = "enable"
 SYSTEMD_SERVICE_${PN} = "rcu-service.service"
 
-do_configure_append() {
-         mkdir -p ${S}/certs
-         echo $NI_ATE_CORE_PRIVATE_KEY > ${S}/certs/ni_ate_core_private.key
-}
-
 do_install() {
          install -d ${D}${bindir}
          install -m 0755 rcu-service ${D}${bindir}


### PR DESCRIPTION
## Justification
This change is part of a series of changes to utilise AzDO's secure file functionality to store and inject the private key file. https://github.com/ni/smartracks-script/pull/33

## Changes
Removed do_configure_append section as the private key file will be added by rcu-image pipeline