### PR TITLE
Add patch to support eth1 in u-boot

### DIFF
--- a/recipes-bsp/u-boot/files/enable-u-boot-eth1.patch
+++ b/recipes-bsp/u-boot/files/enable-u-boot-eth1.patch
@@ -1,0 +1,105 @@
+--- a/arch/arm/dts/fsl-imx8qm-apalis.dts	2023-03-20 11:23:25.160275346 +0800
++++ b/arch/arm/dts/fsl-imx8qm-apalis.dts	2023-03-20 12:52:34.891567569 +0800
+@@ -62,7 +62,7 @@
+ &iomuxc {
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&pinctrl_cam1_gpios>, <&pinctrl_dap1_gpios>,
+-		    <&pinctrl_esai0_gpios>, <&pinctrl_fec2_gpios>,
++		    <&pinctrl_esai0_gpios>,
+ 		    <&pinctrl_gpio12>, <&pinctrl_gpio34>, <&pinctrl_gpio56>,
+ 		    <&pinctrl_gpio7>, <&pinctrl_gpio8>, <&pinctrl_gpio_bkl_on>,
+ 		    <&pinctrl_gpio_keys>, <&pinctrl_gpio_pwm0>,
+@@ -146,6 +146,27 @@
+ 			>;
+ 		};
+ 
++		pinctrl_fec2: fec2grp {
++			fsl,pins = <
++				SC_P_COMP_CTL_GPIO_1V8_3V3_ENET_ENETA_PAD	0x000014a0 /* Use pads in 3.3V mode */
++				SC_P_ENET1_MDC_CONN_ENET1_MDC			0x06000020
++				SC_P_ENET1_MDIO_CONN_ENET1_MDIO			0x06000020
++				SC_P_ENET1_RGMII_TX_CTL_CONN_ENET1_RGMII_TX_CTL	0x06000020
++				SC_P_ENET1_RGMII_TXC_CONN_ENET1_RGMII_TXC	0x06000020
++				SC_P_ENET1_RGMII_TXD0_CONN_ENET1_RGMII_TXD0	0x06000020
++				SC_P_ENET1_RGMII_TXD1_CONN_ENET1_RGMII_TXD1	0x06000020
++				SC_P_ENET1_RGMII_TXD2_CONN_ENET1_RGMII_TXD2	0x06000020
++				SC_P_ENET1_RGMII_TXD3_CONN_ENET1_RGMII_TXD3	0x06000020
++				SC_P_ENET1_RGMII_RXC_CONN_ENET1_RGMII_RXC	0x06000020
++				SC_P_ENET1_RGMII_RX_CTL_CONN_ENET1_RGMII_RX_CTL	0x06000020
++				SC_P_ENET1_RGMII_RXD0_CONN_ENET1_RGMII_RXD0	0x06000020
++				SC_P_ENET1_RGMII_RXD1_CONN_ENET1_RGMII_RXD1	0x06000020
++				SC_P_ENET1_RGMII_RXD2_CONN_ENET1_RGMII_RXD2	0x06000020
++				SC_P_ENET1_RGMII_RXD3_CONN_ENET1_RGMII_RXD3	0x06000020
++				SC_P_ENET1_REFCLK_125M_25M_CONN_ENET1_REFCLK_125M_25M	0x06000020
++			>;
++		};
++
+ 		pinctrl_gpio_bkl_on: gpio-bkl-on {
+ 			fsl,pins = <
+ 				/* Apalis BKL_ON */
+@@ -218,38 +239,6 @@
+ 			>;
+ 		};
+ 
+-		pinctrl_fec2_gpios: fec2gpiosgrp {
+-			fsl,pins = <
+-				SC_P_COMP_CTL_GPIO_1V8_3V3_ENET_ENETA_PAD	0x000014a0
+-				/* Apalis LCD1_R1 */
+-				SC_P_ENET1_MDC_LSIO_GPIO4_IO18			0x00000021
+-				/* Apalis LCD1_R0 */
+-				SC_P_ENET1_MDIO_LSIO_GPIO4_IO17			0x00000021
+-				/* Apalis LCD1_G0 */
+-				SC_P_ENET1_REFCLK_125M_25M_LSIO_GPIO4_IO16	0x00000021
+-				/* Apalis LCD1_R7 */
+-				SC_P_ENET1_RGMII_RX_CTL_LSIO_GPIO6_IO17		0x00000021
+-				/* Apalis LCD1_DE */
+-				SC_P_ENET1_RGMII_RXD0_LSIO_GPIO6_IO18		0x00000021
+-				/* Apalis LCD1_HSYNC */
+-				SC_P_ENET1_RGMII_RXD1_LSIO_GPIO6_IO19		0x00000021
+-				/* Apalis LCD1_VSYNC */
+-				SC_P_ENET1_RGMII_RXD2_LSIO_GPIO6_IO20		0x00000021
+-				/* Apalis LCD1_PCLK */
+-				SC_P_ENET1_RGMII_RXD3_LSIO_GPIO6_IO21		0x00000021
+-				/* Apalis LCD1_R6 */
+-				SC_P_ENET1_RGMII_TX_CTL_LSIO_GPIO6_IO11		0x00000021
+-				/* Apalis LCD1_R5 */
+-				SC_P_ENET1_RGMII_TXC_LSIO_GPIO6_IO10		0x00000021
+-				/* Apalis LCD1_R4 */
+-				SC_P_ENET1_RGMII_TXD0_LSIO_GPIO6_IO12		0x00000021
+-				/* Apalis LCD1_R3 */
+-				SC_P_ENET1_RGMII_TXD1_LSIO_GPIO6_IO13		0x00000021
+-				/* Apalis LCD1_R2 */
+-				SC_P_ENET1_RGMII_TXD2_LSIO_GPIO6_IO14		0x00000021
+-			>;
+-		};
+-
+ 		pinctrl_lvds0_i2c0_gpio: lvds0i2c0gpio {
+ 			fsl,pins = <
+ 				/* Apalis TS_2 */
+@@ -552,6 +541,26 @@
+ 			compatible = "ethernet-phy-ieee802.3-c22";
+ 			reg = <7>;
+ 		};
++	};
++};
++
++&fec2 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_fec2>;
++	fsl,magic-packet;
++	fsl,mii-exclusive;
++	phy-handle = <&ethphy1>;
++	phy-mode = "rgmii";
++	status = "okay";
++
++	mdio {
++		#address-cells = <1>;
++		#size-cells = <0>;
++
++		ethphy1: ethernet-phy@7 {
++			compatible = "ethernet-phy-ieee802.3-c22";
++			reg = <7>;
++		};
+ 	};
+ };
+ 

--- a/recipes-bsp/u-boot/u-boot-toradex_2020.04.bbappend
+++ b/recipes-bsp/u-boot/u-boot-toradex_2020.04.bbappend
@@ -1,3 +1,6 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
-SRC_URI += " file://alter-default-apalis-device-tree.patch "
+SRC_URI += " \
+    file://alter-default-apalis-device-tree.patch \
+    file://enable-u-boot-eth1.patch \
+"


### PR DESCRIPTION
Added enable-u-boot-eth1.patch file, which patches Apalis iMX8 u-boot device tree to add proper fec2 bindings. Tested on Gamora, two mdio controllers show up after configuring eth1addr properly.

For now, TEZI installation is required to install these changes since mender does not alter u-boot. 