### PR TITLE
Add crypt dependencies to rcu-service recipe

### DIFF
--- a/recipes-ni/proprietary/rcu-service/rcu-service-src.inc
+++ b/recipes-ni/proprietary/rcu-service/rcu-service-src.inc
@@ -13,7 +13,7 @@ SRCREV = "${AUTOREV}"
 
 S = "${WORKDIR}/git"
 
-DEPENDS += " python3-grpcio-tools-native"
+DEPENDS += " python3-grpcio-tools-native virtual/crypt "
 RDEPENDS_${PN} += " python3 python3-grpcio "
 inherit python3native
 inherit python3-dir


### PR DESCRIPTION
OE builds complaining about missing crypt.h after https://github.com/ni/rcu-service/pull/266/. This adds the proper dependencies to allow crypt library to be included in rcu-service OE build.

See https://www.yoctoproject.org/pipermail/yocto/2019-May/045481.html