### PR TITLE
Retain private keys, remove private key installation steps

### DIFF
--- a/recipes-mender/rcu-state-scripts/files/retain-ssl-private-keys
+++ b/recipes-mender/rcu-state-scripts/files/retain-ssl-private-keys
@@ -33,7 +33,7 @@ fi
 sleep 2
 
 if [ -d /mnt/etc ]; then
-    cp /etc/ssl/private /mnt/etc/ssl/private
+    cp -r /etc/ssl/private /mnt/etc/ssl/private
     echo "Copied private keys to new root partition" >&2
 else
     echo "Failed to find /etc on new root partition" >&2

--- a/recipes-mender/rcu-state-scripts/files/retain-ssl-private-keys
+++ b/recipes-mender/rcu-state-scripts/files/retain-ssl-private-keys
@@ -1,0 +1,44 @@
+#!/bin/sh
+#
+# Retain RCU SSL/TLS private key from the current root
+#
+
+echo "$(mender show-artifact): Running $(basename "$0")" >&2
+
+# Check if fw_printenv command is available
+if [ ! -x /usr/bin/fw_printenv ]; then
+    exit 1
+fi
+
+# Check current rootfs partition
+current=$(/usr/bin/fw_printenv mender_boot_part | awk -F = '{ print $2 }')
+
+# Deduce target rootfs partition based on current rootfs partition number
+if [ $current = "2" ]; then
+    newroot=/dev/mmcblk0p3
+elif [ $current = "3" ]; then
+    newroot=/dev/mmcblk0p2
+else
+    echo "Unexpected current root: $current" >&2
+    exit 1
+fi
+
+mount $newroot /mnt
+
+if [ $? -ne 0 ]; then
+    echo "Failed to mount $newroot" >&2
+    exit 1
+fi
+
+sleep 2
+
+if [ -d /mnt/etc ]; then
+    cp /etc/ssl/private /mnt/etc/ssl/private
+    echo "Copied private keys to new root partition" >&2
+else
+    echo "Failed to find /etc on new root partition" >&2
+    umount $newroot
+    exit 1
+fi
+
+umount $newroot

--- a/recipes-mender/rcu-state-scripts/rcu-state-scripts_1.0.bb
+++ b/recipes-mender/rcu-state-scripts/rcu-state-scripts_1.0.bb
@@ -6,6 +6,7 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda
 SRC_URI = " \
     file://retain-credentials \
     file://retain-ssh-service-status \
+    file://retain-ssl-private-keys \
 "
 
 inherit mender-state-scripts
@@ -13,4 +14,5 @@ inherit mender-state-scripts
 do_compile() {
     cp ${WORKDIR}/retain-credentials ${MENDER_STATE_SCRIPTS_DIR}/ArtifactInstall_Enter_00
     cp ${WORKDIR}/retain-ssh-service-status ${MENDER_STATE_SCRIPTS_DIR}/ArtifactInstall_Enter_01
+    cp ${WORKDIR}/retain-ssl-private-keys ${MENDER_STATE_SCRIPTS_DIR}/ArtifactInstall_Enter_02
 }

--- a/recipes-ni/proprietary/rcu-service/rcu-service_1.0.bb
+++ b/recipes-ni/proprietary/rcu-service/rcu-service_1.0.bb
@@ -13,8 +13,6 @@ do_install() {
          install -m 0755 rcu-service ${D}${bindir}
          install -d ${D}/${systemd_unitdir}/system
          install -m 0644 ${S}/rcu-service.service ${D}/${systemd_unitdir}/system
-         install -d ${D}/${sysconfdir}/ssl/private
-         install -m 0640 ${S}/certs/ni_ate_core_private.key ${D}/${sysconfdir}/ssl/private
          install -d ${D}/${sysconfdir}/ssl/certs
          install -m 0644 ${S}/certs/ni_ate_core_cert.pem ${D}/${sysconfdir}/ssl/certs
 }


### PR DESCRIPTION
## Justification
Tied to this [User Story](https://dev.azure.com/ni/DevCentral/_workitems/edit/2352123). This is part of a more secure proposal on how to inject the SSL/TLS private key into RCU. 
Current method is to package private key in RCU image and install it to RCU during firmware updates. This is not secure as the RCU image can be unzipped easily to obtain the private key.
New proposal is the have private key injected during RCU FVT.

## Changes
1. Add script to retain private keys during mender updates.
2. Remove installation step for private key.