### PR TITLE
Hotfix for retain ssl private key script

### DIFF
--- a/recipes-mender/rcu-state-scripts/files/retain-ssl-private-keys
+++ b/recipes-mender/rcu-state-scripts/files/retain-ssl-private-keys
@@ -33,7 +33,7 @@ fi
 sleep 2
 
 if [ -d /mnt/etc ]; then
-    cp -r /etc/ssl/private /mnt/etc/ssl/private
+    cp /etc/ssl/private/* /mnt/etc/ssl/private
     echo "Copied private keys to new root partition" >&2
 else
     echo "Failed to find /etc on new root partition" >&2


### PR DESCRIPTION
## Justification
Hotfix for retain ssl private key script as it was incorrectly adding the entire private folder into /etc/ssl/private

## Changes
Use copy of folder contents instead of cp -r

