### PR TITLE
Fix rcuhostname CRC32 checksum comparison

### DIFF
--- a/recipes-core/rcu-hostname/files/rcuhostname
+++ b/recipes-core/rcu-hostname/files/rcuhostname
@@ -19,7 +19,7 @@ if [[ $hostname = null ]]; then
     if [ -f $EEPROM_SYSFS_PATH  ] && [ $(hexdump -v -e '1/1 "%d"' $EEPROM_SYSFS_PATH -s 0 -n 1) = $EEPROM_REV_REQ ] ; then
 
         # EEPROM checksum stored at offset 1, total 4 bytes ( -s 1 -n 4 )
-        EEPROM_CHECKSUM=$printf "%d" 0x$(hexdump -v -e '1/1 "%02x"' $EEPROM_SYSFS_PATH -s 1 -n 4))
+        EEPROM_CHECKSUM=$(printf "%d" 0x$(hexdump -v -e '1/1 "%02x"' $EEPROM_SYSFS_PATH -s 1 -n 4))
 
         # Generate CRC32 from EEPROM content, starting at offset 5, total 981 bytes ( -s 5 -n 981 )
         # 1 byte at offset 5 stores the number of datasets present in the EEPROM. The expected number of datasets in RCU Carrier EEPROM is 5.

--- a/recipes-core/rcu-hostname/files/rcuhostname
+++ b/recipes-core/rcu-hostname/files/rcuhostname
@@ -19,15 +19,15 @@ if [[ $hostname = null ]]; then
     if [ -f $EEPROM_SYSFS_PATH  ] && [ $(hexdump -v -e '1/1 "%d"' $EEPROM_SYSFS_PATH -s 0 -n 1) = $EEPROM_REV_REQ ] ; then
 
         # EEPROM checksum stored at offset 1, total 4 bytes ( -s 1 -n 4 )
-        EEPROM_CHECKSUM=0x$(hexdump -v -e '1/1 "%02x"' $EEPROM_SYSFS_PATH -s 1 -n 4)
+        EEPROM_CHECKSUM=$printf "%d" 0x$(hexdump -v -e '1/1 "%02x"' $EEPROM_SYSFS_PATH -s 1 -n 4))
 
         # Generate CRC32 from EEPROM content, starting at offset 5, total 981 bytes ( -s 5 -n 981 )
         # 1 byte at offset 5 stores the number of datasets present in the EEPROM. The expected number of datasets in RCU Carrier EEPROM is 5.
         # Each dataset is 196 bytes in length. Hence, 1 + (196 * 5) = 981 bytes
-        EEPROM_CRC32_GEN=$(python3 -c "import binascii; print(hex(binascii.crc32(b'$(hexdump -v -e '1/1 "\x%02x"' $EEPROM_SYSFS_PATH -s 5 -n 981)')))")
+        EEPROM_CRC32_GEN=$(python3 -c "import binascii; print(binascii.crc32(b'$(hexdump -v -e '1/1 "\x%02x"' $EEPROM_SYSFS_PATH -s 5 -n 981)'))")
 
         # If RCU Carrier EEPROM checksum is valid, read RCU Carrier Module S/N and form hostname
-        if [ $EEPROM_CHECKSUM == $EEPROM_CRC32_GEN ]; then
+        if [ $EEPROM_CHECKSUM -eq $EEPROM_CRC32_GEN ]; then
 
             # RCU Carrier Module S/N stored at offset 412, total 4 bytes ( -s 412 -n 4)
             hostname="ni-rmx-1010x-"$(hexdump -v -e '1/1 "%02x"' $EEPROM_SYSFS_PATH -s 412 -n 4)


### PR DESCRIPTION
Issue reported by test engineer- CRC32 checksum in hex format generated by python command does not include leading zeros due to use of hex(). String comparison between checksum obtained by hexdump and the python command hence fails (0x1234567 != 0x01234567).

This PR removes hex() from the python command, and converts existing CRC32 checksum in EEPROM to decimal. Comparison proceeds via numeric comparison instead of string comparison. 

Conducted testing on Gamora to verify that checksum validation works:
![image](https://user-images.githubusercontent.com/43567407/230537091-8a069558-1c3f-447c-ba56-c6f29dac87a4.png)

Tested numeric comparison on a separate script via hex values with and without leading zeros. 

Full script sent to SW Test, verified that issue is resolved. 