### PR TITLE
Add Mender state scripts to retain dbus machine-id

### DIFF
--- a/recipes-mender/rcu-state-scripts/files/retain-dbus-machine-id
+++ b/recipes-mender/rcu-state-scripts/files/retain-dbus-machine-id
@@ -1,0 +1,44 @@
+#!/bin/sh
+#
+# Retain dbus machine-id file from the current root
+#
+
+echo "$(mender show-artifact): Running $(basename "$0")" >&2
+
+# Check if fw_printenv command is available
+if [ ! -x /usr/bin/fw_printenv ]; then
+    exit 1
+fi
+
+# Check current rootfs partition
+current=$(/usr/bin/fw_printenv mender_boot_part | awk -F = '{ print $2 }')
+
+# Deduce target rootfs partition based on current rootfs partition number
+if [ $current = "2" ]; then
+    newroot=/dev/mmcblk0p3
+elif [ $current = "3" ]; then
+    newroot=/dev/mmcblk0p2
+else
+    echo "Unexpected current root: $current" >&2
+    exit 1
+fi
+
+mount $newroot /mnt
+
+if [ $? -ne 0 ]; then
+    echo "Failed to mount $newroot" >&2
+    exit 1
+fi
+
+sleep 2
+
+if [ -d /mnt/etc ]; then
+    cp /etc/machine-id /mnt/etc/machine-id
+    echo "Copied machine-id to new root partition" >&2
+else
+    echo "Failed to find /etc on new root partition" >&2
+    umount $newroot
+    exit 1
+fi
+
+umount $newroot

--- a/recipes-mender/rcu-state-scripts/rcu-state-scripts_1.0.bb
+++ b/recipes-mender/rcu-state-scripts/rcu-state-scripts_1.0.bb
@@ -7,6 +7,7 @@ SRC_URI = " \
     file://retain-credentials \
     file://retain-ssh-service-status \
     file://retain-ssl-private-keys \
+    file://retain-dbus-machine-id \
 "
 
 inherit mender-state-scripts
@@ -15,4 +16,5 @@ do_compile() {
     cp ${WORKDIR}/retain-credentials ${MENDER_STATE_SCRIPTS_DIR}/ArtifactInstall_Enter_00
     cp ${WORKDIR}/retain-ssh-service-status ${MENDER_STATE_SCRIPTS_DIR}/ArtifactInstall_Enter_01
     cp ${WORKDIR}/retain-ssl-private-keys ${MENDER_STATE_SCRIPTS_DIR}/ArtifactInstall_Enter_02
+    cp ${WORKDIR}/retain-dbus-machine-id ${MENDER_STATE_SCRIPTS_DIR}/ArtifactInstall_Enter_03
 }


### PR DESCRIPTION
Previously, RCU Mender updates were found to cause RCU IP to change. This causes issues for test automation, as the DNS server records need to be updated and the DNS client needs to refresh its cache to correctly connect to the RCU via hostname.

After investigation, it is found that the dbus machine-id is used for the creation of DHCP host identifier [1]. Machines having the same machine-id can even obtain the same DHCP IP address from a DHCP server, something which happens frequently on cloned VMs [2].

This PR introduces Mender state scripts to retain the /etc/machine-id file across Mender updates. Changes tested on local RCU setup and IP address was observed to not change from update to update after the machine-id file was retained successfully.

[1] https://wiki.debian.org/MachineId
[2] https://superuser.com/questions/1380443/ 