### PR TITLE
Generate grpc pb files for pytest

### DIFF
--- a/recipes-ni/proprietary/rcu-service/rcu-service-python-test-client_1.0.bb
+++ b/recipes-ni/proprietary/rcu-service/rcu-service-python-test-client_1.0.bb
@@ -6,6 +6,7 @@ require rcu-service-src.inc
 do_compile() {
 	python3 -m grpc_tools.protoc -I${S} --python_out=${S}/tests/python --grpc_python_out=${S}/tests/python ${S}/rcu-service.proto
 	python3 -m grpc_tools.protoc -I${S} --python_out=${S}/tests/pytest/rcu_pytest --grpc_python_out=${S}/tests/python ${S}/rcu-service.proto
+	python3 ${S}/tests/pytest/setup.py bdist_wheel -d ${S}/tests/pytest/dist
 }
 
 do_install() {

--- a/recipes-ni/proprietary/rcu-service/rcu-service-python-test-client_1.0.bb
+++ b/recipes-ni/proprietary/rcu-service/rcu-service-python-test-client_1.0.bb
@@ -5,6 +5,7 @@ require rcu-service-src.inc
 
 do_compile() {
 	python3 -m grpc_tools.protoc -I${S} --python_out=${S}/tests/python --grpc_python_out=${S}/tests/python ${S}/rcu-service.proto
+	python3 -m grpc_tools.protoc -I${S} --python_out=${S}/tests/pytest/rcu_pytest --grpc_python_out=${S}/tests/python ${S}/rcu-service.proto
 }
 
 do_install() {


### PR DESCRIPTION
## Justification
Part of changes to add rcu pytest to export feed.

## Changes
Add line in recipe to generate grpc pb files into rcu pytest folders.
Add line in recipe to generate whl file.

## Testing
N/A