### PR TITLE
Fix build dependency issues for building RCU pytest

### DIFF
--- a/recipes-ni/proprietary/rcu-service/rcu-service-src.inc
+++ b/recipes-ni/proprietary/rcu-service/rcu-service-src.inc
@@ -13,7 +13,7 @@ SRCREV = "${AUTOREV}"
 
 S = "${WORKDIR}/git"
 
-DEPENDS += " python3-grpcio-tools-native virtual/crypt "
+DEPENDS += " python3-grpcio-tools-native virtual/crypt python3-wheel-native "
 RDEPENDS_${PN} += " python3 python3-grpcio "
 inherit python3native
 inherit python3-dir

--- a/recipes-ni/proprietary/rcu-service/rcu-service-src.inc
+++ b/recipes-ni/proprietary/rcu-service/rcu-service-src.inc
@@ -13,7 +13,7 @@ SRCREV = "${AUTOREV}"
 
 S = "${WORKDIR}/git"
 
-DEPENDS += " python3-grpcio-tools-native virtual/crypt python3-wheel-native "
+DEPENDS += " python3-grpcio-tools-native virtual/crypt python3-setuptools-native python3-wheel-native "
 RDEPENDS_${PN} += " python3 python3-grpcio "
 inherit python3native
 inherit python3-dir


### PR DESCRIPTION
Follow up to https://github.com/ni/meta-smartracks/pull/108. Saw pipeline build failures complaining about bdist_wheel not being a valid command. Reproduced failures and tested fix on local build machine