### PR TITLE
Fix vsftpd and uSD automount issues 

### DIFF
--- a/recipes-core/udev/files/vsftpd-sd.rules
+++ b/recipes-core/udev/files/vsftpd-sd.rules
@@ -1,3 +1,5 @@
 # Configurations to handle starting and stopping vsftpd.service on SD card hotplug
-KERNEL=="mmcblk1", ACTION=="add"    RUN+="/etc/udev/scripts/vsftpd-sd.sh"
-KERNEL=="mmcblk1", ACTION=="remove"    RUN+="/etc/udev/scripts/vsftpd-sd.sh"
+
+SUBSYSTEM=="block", KERNELS=="mmcblk1p1", ACTION=="add"    RUN+="/etc/udev/scripts/vsftpd-sd.sh"
+SUBSYSTEM=="block", KERNELS=="mmcblk1p1", ACTION=="remove" RUN+="/etc/udev/scripts/vsftpd-sd.sh"
+SUBSYSTEM=="block", KERNELS=="mmcblk1p1", ACTION=="change", ENV{DISK_MEDIA_CHANGE}=="1" RUN+="/etc/udev/scripts/vsftpd-sd.sh"

--- a/recipes-core/udev/files/vsftpd-sd.rules
+++ b/recipes-core/udev/files/vsftpd-sd.rules
@@ -1,5 +1,5 @@
 # Configurations to handle starting and stopping vsftpd.service on SD card hotplug
 
 SUBSYSTEM=="block", KERNELS=="mmcblk1p1", ACTION=="add"    RUN+="/etc/udev/scripts/vsftpd-sd.sh"
-SUBSYSTEM=="block", KERNELS=="mmcblk1p1", ACTION=="remove" RUN+="/etc/udev/scripts/vsftpd-sd.sh"
-SUBSYSTEM=="block", KERNELS=="mmcblk1p1", ACTION=="change", ENV{DISK_MEDIA_CHANGE}=="1" RUN+="/etc/udev/scripts/vsftpd-sd.sh"
+SUBSYSTEM=="block", KERNELS=="mmcblk1p1", ACTION=="add"    RUN+="/bin/systemctl --no-block start vsftpd.service"
+SUBSYSTEM=="block", KERNELS=="mmcblk1p1", ACTION=="remove" RUN+="/bin/systemctl --no-block stop vsftpd.service"

--- a/recipes-core/udev/files/vsftpd-sd.sh
+++ b/recipes-core/udev/files/vsftpd-sd.sh
@@ -2,39 +2,18 @@
 #
 # Called from udev
 #
-# Starts/stops vsftpd.service on SD card hotplug
-
+# Mount uSD with correct permissions to FTP writable location
 
 if [ "$ACTION" = "add" ]; then
-	# Attempt to mount SD card to FTP writable location
-	ftp_uid=$(id -u ftp)
-	ftp_gid=$(id -g ftp)
-	mount -o uid=${ftp_uid},gid=${ftp_gid} /dev/mmcblk1p1 /var/lib/ftp/upload
-	retcode=$?
-	if [ $retcode -eq 0 ]; then
-		logger "Mount success."
-		# Attempt to start vsftpd.service if mount success
-		systemctl start vsftpd
-		retcode=$?
-		if [ $retcode -eq 0 ]; then
-			logger "vsftpd.service has been started by udev."
-		else
-			logger "vsftpd.service failed to start with code: " $retcode
-		fi
-	else
-		logger "Mount failed with code: " $retcode
-	fi
+    ftp_uid=$(id -u ftp)
+    ftp_gid=$(id -g ftp)
 
-elif [ "$ACTION" = "remove" ]; then
-	# Attempt to stop vsftpd.service
-	systemctl stop vsftpd
-	retcode=$?
-	if [ $retcode -eq 0 ]; then
-		logger "vsftpd.service has been stopped by udev."
-	else
-		logger "vsftpd.service failed to stop with code: " $retcode
-	fi
-else
-	# Handling edge case if something unexpected happens
-	logger "Unknown action: $ACTION triggered"
+    MOUNT="systemd-mount -o silent -o uid=${ftp_uid},gid=${ftp_gid}"
+
+    if ! $MOUNT --no-block -t auto $DEVNAME "/var/lib/ftp/upload"
+    then
+        logger "Mount failed failed!"
+    else
+        logger "Mount successful"
+    fi
 fi

--- a/recipes-core/udev/udev-extraconf_%.bbappend
+++ b/recipes-core/udev/udev-extraconf_%.bbappend
@@ -10,4 +10,6 @@ do_install:append() {
 
     install -d ${D}${sysconfdir}/udev/scripts/
     install -m 0755 ${WORKDIR}/vsftpd-sd.sh ${D}${sysconfdir}/udev/scripts/vsftpd-sd.sh
+
+    echo "/dev/mmcblk1p1" >> ${D}${sysconfdir}/udev/mount.ignorelist
 }


### PR DESCRIPTION
Update from Dunfell to Kirkstone appears to have broke automount functionality of uSD. Initially I noticed that uSD was mounted to /media/mmcblk1p1 instead of the FTP writable location, meaning the existing [automount](https://cgit.openembedded.org/openembedded-core/tree/meta/recipes-core/udev/udev-extraconf/automount.rules?h=kirkstone) rules for all block devices were enforced instead. After temporarily removing the default automount rules, mmcblk1p1 still was not mounted correctly to /var/lib/ftp/upload. 

I initially suspected that the new addition of `MountFlags=` or `PrivateMount=` may have been the cause of these issues (see [link](https://unix.stackexchange.com/questions/464959)), but upon further inspection, these flags were already set to not restrict mounting of devices via udev rules and scripts. 

After a lot of experimenting, it seems like the problem was calling `systemctl start vsftpd` within the script which handles mounting the uSD. Somehow, this call prevents uSD from mounting properly. In this PR, we utilize separate rules to start and stop vsftpd.service instead of handling it with the mounting script. Another problem involved our use of `mount` instead of [`systemd-mount`](https://www.freedesktop.org/software/systemd/man/systemd-mount.html), which I guess was necessitated in updates to systemd/udev. These changes allowed uSD to be mounted to the correct location, and for the FTP server to start correctly. I tried accessing the FTP server via WinSCP, and was able to access the log files within the uSD.

Upon reenabling the default automount rules, however, uSD was mounted to /media/mmcblk1p1 again by [mount.sh](https://cgit.openembedded.org/openembedded-core/tree/meta/recipes-core/udev/udev-extraconf/mount.sh?h=kirkstone). In order to prevent this from happening, we add /dev/mmcblk1p1 to /etc/udev/mount.ignorelist, as has been done by Mender [here](https://github.com/mendersoftware/meta-mender-community/blob/kirkstone/meta-mender-toradex-nxp/recipes-core/udev/udev-extraconf_%25.bbappend).