### PR TITLE
Retain public key cert during mender update

### DIFF
--- a/recipes-mender/rcu-state-scripts/files/retain-ssl-key-pair
+++ b/recipes-mender/rcu-state-scripts/files/retain-ssl-key-pair
@@ -35,6 +35,8 @@ sleep 2
 if [ -d /mnt/etc ]; then
     cp /etc/ssl/private/* /mnt/etc/ssl/private
     echo "Copied private keys to new root partition" >&2
+    cp /etc/ssl/certs/ni_ate_core_cert.pem /mnt/etc/ssl/certs/ni_ate_core_cert.pem
+    echo "Copied public key cert to new root partition" >&2
 else
     echo "Failed to find /etc on new root partition" >&2
     umount $newroot

--- a/recipes-mender/rcu-state-scripts/rcu-state-scripts_1.0.bb
+++ b/recipes-mender/rcu-state-scripts/rcu-state-scripts_1.0.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda
 SRC_URI = " \
     file://retain-credentials \
     file://retain-ssh-service-status \
-    file://retain-ssl-private-keys \
+    file://retain-ssl-key-pair \
     file://retain-dbus-machine-id \
 "
 
@@ -15,6 +15,6 @@ inherit mender-state-scripts
 do_compile() {
     cp ${WORKDIR}/retain-credentials ${MENDER_STATE_SCRIPTS_DIR}/ArtifactInstall_Enter_00
     cp ${WORKDIR}/retain-ssh-service-status ${MENDER_STATE_SCRIPTS_DIR}/ArtifactInstall_Enter_01
-    cp ${WORKDIR}/retain-ssl-private-keys ${MENDER_STATE_SCRIPTS_DIR}/ArtifactInstall_Enter_02
+    cp ${WORKDIR}/retain-ssl-key-pair ${MENDER_STATE_SCRIPTS_DIR}/ArtifactInstall_Enter_02
     cp ${WORKDIR}/retain-dbus-machine-id ${MENDER_STATE_SCRIPTS_DIR}/ArtifactInstall_Enter_03
 }


### PR DESCRIPTION
__Justification:__
Retain public key cert during mender update.

AzDO work item: https://dev.azure.com/ni/DevCentral/_workitems/edit/2339903

__Changes:__
- renamed retain-ssl-private-keys to retain-ssl-key-pair
- added copy command to copy public key cert to new root partition
- updated rcu-state-scripts_1.0.bb

__Test:__
Manual test on custom image - pass

echo during mender update:
![image](https://github.com/ni/meta-ateccgen2/assets/27721199/1a1b2403-c458-4db6-8e89-2f514bc23ebf)

md5 hash comparing after mender update:
![image](https://github.com/ni/meta-ateccgen2/assets/27721199/7c5d9ce8-1143-49e3-a701-114d2844e4a0)

![image](https://github.com/ni/meta-ateccgen2/assets/27721199/f6ee6fe1-e703-4d61-81d4-c44fb4c623c8)
