### PR TITLE
Add Mender update sanity check service

### DIFF
--- a/recipes-core/rcu-sanity-check/files/post-update-sanity-check
+++ b/recipes-core/rcu-sanity-check/files/post-update-sanity-check
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+#rm /data/rcu-service/firmware/rcu-update-staged
+
+# TODO: Check if network is up
+# TODO: Check if rcu-service is active
+
+# If sanity check completes successfully, mender commit and set flag
+#mender commit
+#touch /data/rcu-service/firmware/rcu-update-success
+
+# If sanity check fails, mender rollback, set flag and reboot
+#mender rollback
+#touch /data/rcu-service/firmware/rcu-update-failed
+#reboot

--- a/recipes-core/rcu-sanity-check/files/post-update-sanity-check
+++ b/recipes-core/rcu-sanity-check/files/post-update-sanity-check
@@ -1,15 +1,16 @@
 #!/bin/sh
 
-#rm /data/rcu-service/firmware/rcu-update-staged
+rm /data/rcu-service/firmware/update-staged
+rm /etc/rcu-mender-image-firstboot
 
-# TODO: Check if network is up
-# TODO: Check if rcu-service is active
+RCU_SERVICE_STATUS=$(systemctl is-active rcu-service)
+ETH0_STATUS=$(cat /sys/class/net/eth0/operstate)
 
-# If sanity check completes successfully, mender commit and set flag
-#mender commit
-#touch /data/rcu-service/firmware/rcu-update-success
-
-# If sanity check fails, mender rollback, set flag and reboot
-#mender rollback
-#touch /data/rcu-service/firmware/rcu-update-failed
-#reboot
+if [ "$RCU_SERVICE_STATUS" = "active" ]; then
+    mender commit
+    touch /data/rcu-service/firmware/update-succeeded
+    systemctl restart rcu-service
+else
+    mender rollback
+    touch /data/rcu-service/firmware/update-failed
+fi;

--- a/recipes-core/rcu-sanity-check/files/post-update-sanity-check.service
+++ b/recipes-core/rcu-sanity-check/files/post-update-sanity-check.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Service to run RCU sanity check
+After=network.target
+ConditionPathExists=/data/rcu-service/firmware/rcu-update-staged
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/post-update-sanity-check
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes-core/rcu-sanity-check/files/post-update-sanity-check.service
+++ b/recipes-core/rcu-sanity-check/files/post-update-sanity-check.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Service to run RCU sanity check
 After=network.target
-ConditionPathExists=/data/rcu-service/firmware/rcu-update-staged
+ConditionPathExists=/etc/rcu-mender-image-firstboot
 
 [Service]
 Type=oneshot

--- a/recipes-core/rcu-sanity-check/rcu-sanity-check_1.0.bb
+++ b/recipes-core/rcu-sanity-check/rcu-sanity-check_1.0.bb
@@ -8,11 +8,13 @@ inherit systemd
 SRC_URI += " \
     file://post-update-sanity-check \
     file://post-update-sanity-check.service \
+    file://rcu-mender-image-firstboot \
 "
 
 FILES:${PN} = " \
     ${bindir} \
     ${systemd_system_unitdir} \
+    ${sysconfdir} \
 "
 
 SYSTEMD_SERVICE:${PN} = " \
@@ -24,4 +26,6 @@ do_install () {
     install -m 0755 ${WORKDIR}/post-update-sanity-check ${D}${bindir}
     install -d ${D}${systemd_system_unitdir}
     install -m 0644 ${WORKDIR}/post-update-sanity-check.service ${D}${systemd_system_unitdir}
+    install -d ${D}${sysconfdir}
+    install -m 0644 ${WORKDIR}/rcu-mender-image-firstboot ${D}${sysconfdir}
 }

--- a/recipes-core/rcu-sanity-check/rcu-sanity-check_1.0.bb
+++ b/recipes-core/rcu-sanity-check/rcu-sanity-check_1.0.bb
@@ -1,0 +1,27 @@
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+inherit systemd
+
+SRC_URI += " \
+    file://post-update-sanity-check \
+    file://post-update-sanity-check.service \
+"
+
+FILES:${PN} = " \
+    ${bindir} \
+    ${systemd_system_unitdir} \
+"
+
+SYSTEMD_SERVICE:${PN} = " \
+    post-update-sanity-check.service \
+"
+
+do_install () {
+    install -d ${D}${bindir}
+    install -m 0755 ${WORKDIR}/post-update-sanity-check ${D}${bindir}
+    install -d ${D}${systemd_system_unitdir}
+    install -m 0644 ${WORKDIR}/post-update-sanity-check.service ${D}${systemd_system_unitdir}
+}

--- a/recipes-images/images/packagegroup-ni-cli.bb
+++ b/recipes-images/images/packagegroup-ni-cli.bb
@@ -22,6 +22,7 @@ RRECOMMENDS:packagegroup-base-ni-cli = "\
     coreutils \
     rcu-image-version \
     rcu-state-scripts \
+    rcu-sanity-check \
     udev-ni-rules \
     keyutils \
     cifs-utils \


### PR DESCRIPTION
PR to add a post-Mender-update RCU sanity check script. The current logic is primitive- On image installation, /etc/rcu-mender-image-firstboot file is installed. This file serves as a flag for RCU to run the sanity check service, which removes the flag, then checks if rcu-service is running. If rcu-service is running, mender commit, flag a successful update and restart rcu-service so the flag gets read. If rcu-service fails to run, mender rollback (and wait for user to power cycle the rack/RCU).

Flags which will be interpreted by rcu-service for deducing last update status (pending code update):
/data/rcu-service/firmware/update-staged
/data/rcu-service/firmware/update-failed
/data/rcu-service/firmware/update-succeeded

There is a chance that an image is faulty and not even able to boot to userspace- The sanity check script will not even be executed. In this case, the plan is that once the RCU boots to the old image after an automatic reboot or a power cycle, rcu-service will still be able to interpret the existence of 'update-staged' flag and deduce that the sanity check script failed to remove this.

Another potential case to handle is how the script behaves on TEZI installation- As the script is right now, it will run but will not locate the 'update-staged' flag, nor will mender commit or rollback commands work. However, this should not cause any issues. A way to address this could be to only install the /etc/rcu-mender-image-firstboot file via Mender state scripts- That will require some additional work to get right. 

Some additional checks I would like to include in this involves checking if the RCU image version is as expected after an update- This again requires some work on rcu-service side. We can add it in when the rcu-service code is ready. 