### PR TITLE
cd to pytest directory before building whl file

### DIFF
--- a/recipes-ni/proprietary/rcu-service/rcu-service-python-test-client_1.0.bb
+++ b/recipes-ni/proprietary/rcu-service/rcu-service-python-test-client_1.0.bb
@@ -6,7 +6,8 @@ require rcu-service-src.inc
 do_compile() {
 	python3 -m grpc_tools.protoc -I${S} --python_out=${S}/tests/python --grpc_python_out=${S}/tests/python ${S}/rcu-service.proto
 	python3 -m grpc_tools.protoc -I${S} --python_out=${S}/tests/pytest/rcu_pytest --grpc_python_out=${S}/tests/python ${S}/rcu-service.proto
-	python3 ${S}/tests/pytest/setup.py bdist_wheel -d ${S}/tests/pytest/dist
+	cd ${S}/tests/pytest
+	python3 setup.py bdist_wheel
 }
 
 do_install() {


### PR DESCRIPTION
## Justification
To resolve this [Bug](https://dev.azure.com/ni/DevCentral/_workitems/edit/2492392) where whl in export is empty.

## Changes
Root cause of the issue is due to `setup.py bdist_wheel` being called from the root directory instead of the pytest directory. Detailed explanation can be found [here](https://stackoverflow.com/questions/64952572/output-directories-for-python-setup-py-sdist-bdist-wheel)

## Testings
N/A