### PR TITLE
Install public key and enable Mender artifact verification

### DIFF
--- a/recipes-core/mender/files/mender.conf
+++ b/recipes-core/mender/files/mender.conf
@@ -1,0 +1,3 @@
+{
+    "ArtifactVerifyKey" : "/etc/mender/ateccgen2-rsa-public.key"
+}

--- a/recipes-core/mender/mender-client_%.bbappend
+++ b/recipes-core/mender/mender-client_%.bbappend
@@ -1,3 +1,8 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+SRC_URI:append = " file://ateccgen2-rsa-public.key \
+                   file://mender.conf \
+"
+
 # Disable Mender to run as a system service automatically at boot as refer to 
 # https://docs.mender.io/system-updates-yocto-project/customize-mender#disabling-mender-as-a-system-service
 # Comment out line below to enable mender running as a systemd service as it has been enabled in meta-mender/meta-mender-core/recipes-mender/mender-client.inc

--- a/recipes-core/mender/mender-client_%.bbappend
+++ b/recipes-core/mender/mender-client_%.bbappend
@@ -3,6 +3,11 @@ SRC_URI:append = " file://ateccgen2-rsa-public.key \
                    file://mender.conf \
 "
 
+do_install:append() {
+    install -d ${D}${sysconfdir}/mender
+    install -m 0644 ${WORKDIR}/ateccgen2-rsa-public.key ${D}${sysconfdir}/mender
+}
+
 # Disable Mender to run as a system service automatically at boot as refer to 
 # https://docs.mender.io/system-updates-yocto-project/customize-mender#disabling-mender-as-a-system-service
 # Comment out line below to enable mender running as a systemd service as it has been enabled in meta-mender/meta-mender-core/recipes-mender/mender-client.inc


### PR DESCRIPTION
mender-client.bbappend recipe changes to install public key used for verifying signed RCU Mender images. The public key is empty here, and the real public key shall be used to replace this empty file in pipeline builds. After this change, Mender will try to verify signed images prior to installation. This can be disabled by manually removing the `ArtifactVerifyKey` attribute in mender.conf during runtime. 