### PR TITLE
Fix the grpc output path

### DIFF
--- a/recipes-ni/proprietary/rcu-service/rcu-service-python-test-client_1.0.bb
+++ b/recipes-ni/proprietary/rcu-service/rcu-service-python-test-client_1.0.bb
@@ -5,7 +5,7 @@ require rcu-service-src.inc
 
 do_compile() {
 	python3 -m grpc_tools.protoc -I${S} --python_out=${S}/tests/python --grpc_python_out=${S}/tests/python ${S}/rcu-service.proto
-	python3 -m grpc_tools.protoc -I${S} --python_out=${S}/tests/pytest/rcu_pytest --grpc_python_out=${S}/tests/python ${S}/rcu-service.proto
+	python3 -m grpc_tools.protoc -I${S} --python_out=${S}/tests/pytest/rcu_pytest --grpc_python_out=${S}/tests/pytest/rcu_pytest ${S}/rcu-service.proto
 	cd ${S}/tests/pytest
 	python3 setup.py bdist_wheel
 }


### PR DESCRIPTION
## Justification
Exported whl file was incomplete and missing rcu_service_pb2_grpc file.

## Changes
Changed grpc_python_out to rcu_pytest path

## Testing
N/A