### PR TITLE
Hotfix stub Mender public key filename

### DIFF
--- a/recipes-core/mender/files/mender.conf
+++ b/recipes-core/mender/files/mender.conf
@@ -1,3 +1,3 @@
 {
-    "ArtifactVerifyKey" : "/etc/mender/ateccgen2-rsa-public.key"
+    "ArtifactVerifyKey" : "/etc/mender/ateccgen2_rsa_public.key"
 }

--- a/recipes-core/mender/mender-client_%.bbappend
+++ b/recipes-core/mender/mender-client_%.bbappend
@@ -1,11 +1,11 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
-SRC_URI:append = " file://ateccgen2-rsa-public.key \
+SRC_URI:append = " file://ateccgen2_rsa_public.key \
                    file://mender.conf \
 "
 
 do_install:append() {
     install -d ${D}${sysconfdir}/mender
-    install -m 0644 ${WORKDIR}/ateccgen2-rsa-public.key ${D}${sysconfdir}/mender
+    install -m 0644 ${WORKDIR}/ateccgen2_rsa_public.key ${D}${sysconfdir}/mender
 }
 
 # Disable Mender to run as a system service automatically at boot as refer to 


### PR DESCRIPTION
Made a silly mistake where I used dashes instead of underscores for the public key filename. Fixing this so it matches the use of underscores as in the private key filename. 