### PR TITLE
Create RCU Mender image firstboot flag

### DIFF
--- a/recipes-core/mender/mender-client_%.bbappend
+++ b/recipes-core/mender/mender-client_%.bbappend
@@ -1,11 +1,13 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 SRC_URI:append = " file://ateccgen2_rsa_public.key \
                    file://mender.conf \
+                   file://rcu-mender-image-firstboot \
 "
 
 do_install:append() {
     install -d ${D}${sysconfdir}/mender
     install -m 0644 ${WORKDIR}/ateccgen2_rsa_public.key ${D}${sysconfdir}/mender
+    install -m 0644 ${WORKDIR}/rcu-mender-image-firstboot ${D}${sysconfdir}/mender
 }
 
 # Disable Mender to run as a system service automatically at boot as refer to 


### PR DESCRIPTION
In conjunction with https://github.com/ni/rcu-service/pull/341, implementation requires a flag which notifies rcu-service that the RCU is booting up for the first time after a new RCU firmware update. Depending on whether rcu-service can run successfully, rcu-service will then respond by removing this firstboot flag and performing mender commit. 