### PR TITLE
Fix issue with hostname not persisting after Mender updates

### DIFF
--- a/recipes-core/rcu-hostname/files/rcuhostname
+++ b/recipes-core/rcu-hostname/files/rcuhostname
@@ -4,9 +4,9 @@
 
 hostname=null
 
-# Try to grab custom hostname from .rackconfig.json
-if [ -f /data/rcu-service/config/.rackconfig.json ]; then
-    hostname=$(jq -r .SETTINGS[0].Hostname /data/rcu-service/config/.rackconfig.json)
+# Try to grab custom hostname from .userconfig.json
+if [ -f /data/rcu-service/config/.userconfig.json ]; then
+    hostname=$(jq -r .SETTINGS[0].Hostname /data/rcu-service/config/.userconfig.json)
 fi
 
 # If custom hostname does not exist in JSON config file, try to grab RCU Carrier Module S/N from EEPROM


### PR DESCRIPTION
PR to address [BUG 2519527](https://dev.azure.com/ni/DevCentral/_workitems/edit/2519527). Issue is stemming from transition from .rackconfig.json to .userconfig.json for storing user customized data, which includes rack hostname. 