### PR TITLE
Alter method for determining current active partition

### DIFF
--- a/recipes-mender/rcu-state-scripts/files/retain-credentials
+++ b/recipes-mender/rcu-state-scripts/files/retain-credentials
@@ -5,13 +5,8 @@
 
 echo "$(mender show-artifact): Running $(basename "$0")" >&2
 
-# Check if fw_printenv command is available
-if [ ! -x /usr/bin/fw_printenv ]; then
-    exit 1
-fi
-
 # Check current rootfs partition
-current=$(/usr/bin/fw_printenv mender_boot_part | awk -F = '{ print $2 }')
+current=$(cat /proc/cmdline | awk -F' ' '{ gsub("root=/dev/mmcblk0p", ""); print $2 }')
 
 # Deduce target rootfs partition based on current rootfs partition number
 if [ $current = "2" ]; then

--- a/recipes-mender/rcu-state-scripts/files/retain-credentials
+++ b/recipes-mender/rcu-state-scripts/files/retain-credentials
@@ -6,12 +6,12 @@
 echo "$(mender show-artifact): Running $(basename "$0")" >&2
 
 # Check current rootfs partition
-current=$(cat /proc/cmdline | awk -F' ' '{ gsub("root=/dev/mmcblk0p", ""); print $2 }')
+current=$(mount | awk '$3 == "/" {print $1}')
 
 # Deduce target rootfs partition based on current rootfs partition number
-if [ $current = "2" ]; then
+if [ $current = "/dev/mmcblk0p2" ]; then
     newroot=/dev/mmcblk0p3
-elif [ $current = "3" ]; then
+elif [ $current = "/dev/mmcblk0p3" ]; then
     newroot=/dev/mmcblk0p2
 else
     echo "Unexpected current root: $current" >&2

--- a/recipes-mender/rcu-state-scripts/files/retain-dbus-machine-id
+++ b/recipes-mender/rcu-state-scripts/files/retain-dbus-machine-id
@@ -5,13 +5,8 @@
 
 echo "$(mender show-artifact): Running $(basename "$0")" >&2
 
-# Check if fw_printenv command is available
-if [ ! -x /usr/bin/fw_printenv ]; then
-    exit 1
-fi
-
 # Check current rootfs partition
-current=$(/usr/bin/fw_printenv mender_boot_part | awk -F = '{ print $2 }')
+current=$(cat /proc/cmdline | awk -F' ' '{ gsub("root=/dev/mmcblk0p", ""); print $2 }')
 
 # Deduce target rootfs partition based on current rootfs partition number
 if [ $current = "2" ]; then

--- a/recipes-mender/rcu-state-scripts/files/retain-dbus-machine-id
+++ b/recipes-mender/rcu-state-scripts/files/retain-dbus-machine-id
@@ -6,12 +6,12 @@
 echo "$(mender show-artifact): Running $(basename "$0")" >&2
 
 # Check current rootfs partition
-current=$(cat /proc/cmdline | awk -F' ' '{ gsub("root=/dev/mmcblk0p", ""); print $2 }')
+current=$(mount | awk '$3 == "/" {print $1}')
 
 # Deduce target rootfs partition based on current rootfs partition number
-if [ $current = "2" ]; then
+if [ $current = "/dev/mmcblk0p2" ]; then
     newroot=/dev/mmcblk0p3
-elif [ $current = "3" ]; then
+elif [ $current = "/dev/mmcblk0p3" ]; then
     newroot=/dev/mmcblk0p2
 else
     echo "Unexpected current root: $current" >&2

--- a/recipes-mender/rcu-state-scripts/files/retain-ssh-service-status
+++ b/recipes-mender/rcu-state-scripts/files/retain-ssh-service-status
@@ -5,13 +5,8 @@
 
 echo "$(mender show-artifact): Running $(basename "$0")" >&2
 
-# Check if fw_printenv command is available
-if [ ! -x /usr/bin/fw_printenv ]; then
-    exit 1
-fi
-
 # Check current rootfs partition
-current=$(/usr/bin/fw_printenv mender_boot_part | awk -F = '{ print $2 }')
+current=$(cat /proc/cmdline | awk -F' ' '{ gsub("root=/dev/mmcblk0p", ""); print $2 }')
 
 # Deduce target rootfs partition based on current rootfs partition number
 if [ $current = "2" ]; then

--- a/recipes-mender/rcu-state-scripts/files/retain-ssh-service-status
+++ b/recipes-mender/rcu-state-scripts/files/retain-ssh-service-status
@@ -6,12 +6,12 @@
 echo "$(mender show-artifact): Running $(basename "$0")" >&2
 
 # Check current rootfs partition
-current=$(cat /proc/cmdline | awk -F' ' '{ gsub("root=/dev/mmcblk0p", ""); print $2 }')
+current=$(mount | awk '$3 == "/" {print $1}')
 
 # Deduce target rootfs partition based on current rootfs partition number
-if [ $current = "2" ]; then
+if [ $current = "/dev/mmcblk0p2" ]; then
     newroot=/dev/mmcblk0p3
-elif [ $current = "3" ]; then
+elif [ $current = "/dev/mmcblk0p3" ]; then
     newroot=/dev/mmcblk0p2
 else
     echo "Unexpected current root: $current" >&2

--- a/recipes-mender/rcu-state-scripts/files/retain-ssl-key-pair
+++ b/recipes-mender/rcu-state-scripts/files/retain-ssl-key-pair
@@ -5,13 +5,8 @@
 
 echo "$(mender show-artifact): Running $(basename "$0")" >&2
 
-# Check if fw_printenv command is available
-if [ ! -x /usr/bin/fw_printenv ]; then
-    exit 1
-fi
-
 # Check current rootfs partition
-current=$(/usr/bin/fw_printenv mender_boot_part | awk -F = '{ print $2 }')
+current=$(cat /proc/cmdline | awk -F' ' '{ gsub("root=/dev/mmcblk0p", ""); print $2 }')
 
 # Deduce target rootfs partition based on current rootfs partition number
 if [ $current = "2" ]; then

--- a/recipes-mender/rcu-state-scripts/files/retain-ssl-key-pair
+++ b/recipes-mender/rcu-state-scripts/files/retain-ssl-key-pair
@@ -6,12 +6,12 @@
 echo "$(mender show-artifact): Running $(basename "$0")" >&2
 
 # Check current rootfs partition
-current=$(cat /proc/cmdline | awk -F' ' '{ gsub("root=/dev/mmcblk0p", ""); print $2 }')
+current=$(mount | awk '$3 == "/" {print $1}')
 
 # Deduce target rootfs partition based on current rootfs partition number
-if [ $current = "2" ]; then
+if [ $current = "/dev/mmcblk0p2" ]; then
     newroot=/dev/mmcblk0p3
-elif [ $current = "3" ]; then
+elif [ $current = "/dev/mmcblk0p3" ]; then
     newroot=/dev/mmcblk0p2
 else
     echo "Unexpected current root: $current" >&2


### PR DESCRIPTION
### Description
During driver implementation of rack firmware update API, it was recently discovered that performing updates multiple times without rebooting will cause the update to fail and rollback to the existing image version. Initial inspection revealed that the files which were supposed to be copied into the new partition were not copied correctly. 

Eventually, we managed to narrow it down to the use of `mender_boot_part` bootloader variable for determining the current active partition. Since `mender_boot_part` flips between the A/B Mender partitions when the first update is performed, this causes issues for the subsequent update taking place prior to rebooting the RCU. This problem should be applicable to both Mender updates triggered from rcu-service, as well as Mender updates triggered via SSH/serial.

### Solution
This PR replaces the use of `mender_boot_part` in state scripts with information found using the `mount` command. The `mount` command lists the partitions which are currently mounted on the RCU, and is able to tell if mmcblk0p2 or mmcblkp3 is mounted as root, making it ideal for the purpose required by state scripts. The expected behavior after this PR is merged is that the new image built from these changes should allow consecutive Mender updates prior to any reboots, to just work.

### Testing
Testing is conducted on the script level to ensure that the scripts run without errors, but a full test will require the image be built first then used for testing. Verified that root partition listed under `mount` changes between mmcblk0p2 and mmcblk0p3 accordingly after mender install + reboot, but not mender install alone. 