### PR TITLE
Fix RCU Image default password hash

### DIFF
--- a/recipes-images/images/ateccgen2-base-image.inc
+++ b/recipes-images/images/ateccgen2-base-image.inc
@@ -14,7 +14,7 @@ COPY_LIC_DIRS ?= "1"
 
 # Configure base image root account default password
 inherit extrausers
-EXTRA_USERS_PARAMS = "usermod -p $6$8fnflVsupDVBSQbB$4xgecuvZxzpoDMAOs9QAQAykaKA.xF8kSthsvkdkHjkPnoKvwjQLetNEePT.ZTBFdwAIii0XzbwNrRiRDJZ.q1 root;"
+EXTRA_USERS_PARAMS = "usermod -p \$6\$8fnflVsupDVBSQbB\$4xgecuvZxzpoDMAOs9QAQAykaKA.xF8kSthsvkdkHjkPnoKvwjQLetNEePT.ZTBFdwAIii0XzbwNrRiRDJZ.q1 root;"
 
 add_rootfs_version () {
     printf "${DISTRO_NAME} ${DISTRO_VERSION} (${DISTRO_CODENAME}) \\\n \\\l\n" > ${IMAGE_ROOTFS}/etc/issue


### PR DESCRIPTION
Issue found during testing of new RCU. Failed to login to image flashed via TEZI using default password. After investigating the issue, turns out the `$` character needs to be escaped. Tested the usermod command on Gamora and verified that password is correct after the change. 