### PR TITLE
Remove Wifi, BT, sound and other unused components from image

### DIFF
--- a/conf/machine/include/apalis-imx8.inc
+++ b/conf/machine/include/apalis-imx8.inc
@@ -1,0 +1,3 @@
+DISTRO_FEATURES:remove = " 3g alsa bluetooth wifi nfc "
+MACHINE_FEATURES:remove = " alsa bluetooth wifi "
+

--- a/recipes-images/images/ateccgen2-base-image.inc
+++ b/recipes-images/images/ateccgen2-base-image.inc
@@ -29,7 +29,7 @@ IMAGE_LINGUAS = "en-us"
 #IMAGE_LINGUAS = "de-de fr-fr en-gb en-us pt-br es-es kn-in ml-in ta-in"
 
 # Remove conflicting packages recommended by packagegroup-base-tdx-cli
-BAD_RECOMMENDATIONS = "set-hostname udev-toradex-rules"
+BAD_RECOMMENDATIONS = " set-hostname udev-toradex-rules "
 
 IMAGE_INSTALL += " \
     packagegroup-boot \

--- a/recipes-kernel/linux/files/ateccgen2.cfg
+++ b/recipes-kernel/linux/files/ateccgen2.cfg
@@ -18,7 +18,4 @@ CONFIG_CIFS=m
 # CONFIG_BT is not set
 # CONFIG_RFKILL is not set
 # CONFIG_CFG80211 is not set
-# CONFIG_SOUND is not set
 # CONFIG_CAN is not set
-# CONFIG_WIRELESS is not set
-

--- a/recipes-kernel/linux/files/ateccgen2.cfg
+++ b/recipes-kernel/linux/files/ateccgen2.cfg
@@ -14,3 +14,11 @@ CONFIG_BMP280=y
 CONFIG_BMP280_I2C=y
 CONFIG_BMP280_SPI=y
 CONFIG_CIFS=m
+# CONFIG_WLAN is not set
+# CONFIG_BT is not set
+# CONFIG_RFKILL is not set
+# CONFIG_CFG80211 is not set
+# CONFIG_SOUND is not set
+# CONFIG_CAN is not set
+# CONFIG_WIRELESS is not set
+


### PR DESCRIPTION
PR to remove unused components from RCU image. ~10MB reduction in terms of image size. 

Testing: Built and tested image on RCU + fanout board setup. Verified that image no longer contains BT and Wifi related kernel modules and packages. 