### PR TITLE
Fix image default password hash

### DIFF
--- a/recipes-images/images/ateccgen2-base-image.inc
+++ b/recipes-images/images/ateccgen2-base-image.inc
@@ -14,7 +14,7 @@ COPY_LIC_DIRS ?= "1"
 
 # Configure base image root account default password
 inherit extrausers
-EXTRA_USERS_PARAMS = "usermod -p \$6\$8fnflVsupDVBSQbB\$4xgecuvZxzpoDMAOs9QAQAykaKA.xF8kSthsvkdkHjkPnoKvwjQLetNEePT.ZTBFdwAIii0XzbwNrRiRDJZ.q1 root;"
+EXTRA_USERS_PARAMS = "usermod -p '\$6\$8fnflVsupDVBSQbB\$4xgecuvZxzpoDMAOs9QAQAykaKA.xF8kSthsvkdkHjkPnoKvwjQLetNEePT.ZTBFdwAIii0XzbwNrRiRDJZ.q1' root;"
 
 add_rootfs_version () {
     printf "${DISTRO_NAME} ${DISTRO_VERSION} (${DISTRO_CODENAME}) \\\n \\\l\n" > ${IMAGE_ROOTFS}/etc/issue


### PR DESCRIPTION
Fix in https://github.com/ni/meta-ateccgen2/pull/128 found to be ineffective. `usermod` appears to work slightly different in Yocto builds compared to running commands directly on the RCU. Single quotes are needed to wrap around the hash for the hash to be written correctly to the shadow file. 

Testing: Built image with fix. Inspected shadow file inside TEZI file.