### PR TITLE
Add PCA9671 16-bit IO expander support for VHP PEPs

### DIFF
--- a/recipes-kernel/linux/files/imx8-apalis-smartracks.dtsi
+++ b/recipes-kernel/linux/files/imx8-apalis-smartracks.dtsi
@@ -208,6 +208,19 @@
         gpio-line-names =
             "IOXPD2_IO0_0", "IOXPD2_IO0_1", "IOXPD2_IO0_2", "IOXPD2_IO0_3", "IOXPD2_IO0_4", "IOXPD2_IO0_5", "IOXPD2_IO0_6", "IOXPD2_IO0_7";
     };
+
+    /* PCA9671 16-bit IO expander on I2C3 */
+    pca9671: gpio@21 {
+        compatible = "nxp,pca9671";
+        reg = <0x21>;
+        gpio-controller;
+        #gpio-cells = <2>;
+        label = "pca9671-57226000.gpio";
+        lines-initial-states = <0x00>;
+        gpio-line-names =
+            "IOXPD2_IO0_0", "IOXPD2_IO0_1", "IOXPD2_IO0_2", "IOXPD2_IO0_3", "IOXPD2_IO0_4", "IOXPD2_IO0_5", "IOXPD2_IO0_6", "IOXPD2_IO0_7",
+            "IOXPD2_IO1_0", "IOXPD2_IO1_1", "IOXPD2_IO1_2", "IOXPD2_IO1_3", "IOXPD2_IO1_4", "IOXPD2_IO1_5", "IOXPD2_IO1_6", "IOXPD2_IO1_7";
+    };
 };
 
 /* Parent node to enable i2c0_lvds0 & i2c1_lvds0 */


### PR DESCRIPTION
PR to address [US 2686624](https://dev.azure.com/ni/DevCentral/_workitems/edit/2686624). Add support for PCA9671 in device tree. Only either the PCA9674 on RCU I2C3 0x20, or the PCA9671 on RCU I2C3 0x21 will be present at one time. If the physical I/O expander is not present in the rack, the driver probe is expected to fail without affecting anything else.

We don't know what the `lines-initial-states` property should be right now, but we can add that once we get more information from HW. `gpio-line-names` could also be subjected to further change.

Testing: Changes built successfully on dev build machine. To be validated once VHP PEP exists,