### PR TITLE
Prevent emc2303 fan driver from reporting 1875 RPM reading

### DIFF
--- a/recipes-kernel/linux/files/0001-hwmon-add-support-for-SMSC-EMC2303.patch
+++ b/recipes-kernel/linux/files/0001-hwmon-add-support-for-SMSC-EMC2303.patch
@@ -494,7 +494,7 @@ index 00000000..b2ae311
 +	if (status < 0)
 +		return status;
 +
-+	if (fan->tach != 0)
++	if ((fan->tach != 0) && (fan->tach != 0x1fff))
 +		rpm = FAN_RPM_FACTOR / fan->tach;
 +	return sprintf(buf, "%d\n", rpm);
 +}

--- a/recipes-kernel/linux/files/0001-hwmon-add-support-for-SMSC-EMC2303.patch
+++ b/recipes-kernel/linux/files/0001-hwmon-add-support-for-SMSC-EMC2303.patch
@@ -494,7 +494,7 @@ index 00000000..b2ae311
 +	if (status < 0)
 +		return status;
 +
-+	if ((fan->tach != 0) && ((fan->tach & 0x1fff) != 0x1fff))
++	if ((fan->tach != 0) && ((fan->tach & 0x1ffc) != 0x1ffc))
 +		rpm = FAN_RPM_FACTOR / fan->tach;
 +	return sprintf(buf, "%d\n", rpm);
 +}

--- a/recipes-kernel/linux/files/0001-hwmon-add-support-for-SMSC-EMC2303.patch
+++ b/recipes-kernel/linux/files/0001-hwmon-add-support-for-SMSC-EMC2303.patch
@@ -494,7 +494,7 @@ index 00000000..b2ae311
 +	if (status < 0)
 +		return status;
 +
-+	if ((fan->tach != 0) && (fan->tach != 0x1fff))
++	if ((fan->tach != 0) && ((fan->tach & 0x1fff) != 0x1fff))
 +		rpm = FAN_RPM_FACTOR / fan->tach;
 +	return sprintf(buf, "%d\n", rpm);
 +}


### PR DESCRIPTION
Spent some time reviewing the [emc2303 datasheet](https://ww1.microchip.com/downloads/aemDocuments/documents/MSLD/ProductDocuments/DataSheets/EMC2301-2-3-5-Data-Sheet-DS20006532A.pdf) as well as the existing patch which adds driver support for emc2303 in our meta layer.

EMC2303 registers involved in reading fan tach are 0x3e (high byte) and 0x3f (low byte). 
![image](https://github.com/user-attachments/assets/ff557d9e-58e3-4737-8f08-40a8dd954676)

Default value for these two bytes are 0xff and 0xf8 respectively (i.e., 1111 1111 and 11111000). The reason for this is because 8 bits in the high byte and only 5 bits in the low byte are involved in determining fan tach reading:
![image](https://github.com/user-attachments/assets/363c42a6-f8df-44e5-b496-2310a8abe44d)

The driver combines high byte and low byte via the following operation:
```cpp
*output = ((u16)high_byte << 5) | (lo_byte >> 3);
```
where high byte is leftshifted by 5 to make way for the 5 meaningful bits in low byte, then combined with bitwise OR.

Taking into account the default values for these two bytes, this would make the default tach reading 0001 1111 1111 1111 (0x1fff). It is also the highest possible register reading which can possibly be read from these two registers. 

The way these register readings are used to calculate the actual RPM value is listed here:
![image](https://github.com/user-attachments/assets/475f8935-0475-4bfa-8d3d-283a2ddb788e)

Using the default register values, the watered-down version of the driver operation is show in code below:
```cpp
#define FAN_TACH_EDGES 5
#define FAN_POLES      2
#define FAN_MULTIPLIER 4
#define FAN_CLK_FREQ   32000

/* Apply Equation 4-2 from datasheet */
#define FAN_RPM_FACTOR (((FAN_TACH_EDGES - 1) * FAN_MULTIPLIER * FAN_CLK_FREQ * 60) / FAN_POLES) // 15360000

uint16_t tach = ((uint16_t)0xff << 5) | (0xf8 >> 3); // This gives 0x1fff
int RPM = FAN_RPM_FACTOR / tach; // 1875
```
This is one of the ways how the value of 1875 can be obtained. It also means that 1875 is the lowest possible RPM reading which can be obtained from the driver (given the existing fan configuration). When modifying the kernel driver to print the actual tach register values when fan is not powered, the value of 8188 (or 0x1ffc) is obtained instead of 0x1fff.
![image](https://github.com/user-attachments/assets/a465adac-b411-4323-bee3-e63fbac1aa05)
The exact reason for this is still unknown, but 0x1ffc is the smallest denominator which can result in RPM reading of 1875. 0x1ffb, for example, results in 1876. 

This PR proposes to allow the driver to report a RPM reading of 0 when fan tach is found to be >= 0x1ffc. (Reason being values 0x1ffc to 0x1fff will result in the 1875 reading)

##Testing

Testing conducted on Widow:
![image](https://github.com/user-attachments/assets/151ce4ff-62af-45f6-84ab-ba59aa288824)
