### PR TITLE
Add device tree overlays to support multirack IO expanders

### DIFF
--- a/recipes-kernel/linux/device-tree-overlays_git.bbappend
+++ b/recipes-kernel/linux/device-tree-overlays_git.bbappend
@@ -1,1 +1,15 @@
 TEZI_EXTERNAL_KERNEL_DEVICETREE_BOOT:apalis-imx8 = " apalis-imx8_hdmi_overlay.dtbo "
+
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+SRC_URI += " \
+    file://apalis-imx8_multirack-2rack_overlay.dts \
+    file://apalis-imx8_multirack-3rack_overlay.dts \
+"
+
+do_collect_overlays:prepend() {
+    # Copy custom overlays into Toradex workdir defined in toradex-devicetree.bbclass
+    cp ${WORKDIR}/apalis-imx8_multirack-2rack_overlay.dts ${S}
+    cp ${WORKDIR}/apalis-imx8_multirack-3rack_overlay.dts ${S}
+}
+

--- a/recipes-kernel/linux/files/apalis-imx8_multirack-2rack_overlay.dts
+++ b/recipes-kernel/linux/files/apalis-imx8_multirack-2rack_overlay.dts
@@ -42,12 +42,6 @@
         lines-initial-states = <0x00>;
         gpio-line-names =
             "IOXPD2_IO0_0", "IOXPD2_IO0_1", "IOXPD2_IO0_2", "IOXPD2_IO0_3", "IOXPD2_IO0_4", "IOXPD2_IO0_5", "IOXPD2_IO0_6", "IOXPD2_IO0_7";
-
-        ioxpd_debug_line {
-            gpio-hog;
-            gpios = <6 GPIO_ACTIVE_HIGH>;
-            output-high;
-        };
     };
     
     /* PCA9674 8-bit IO expander on I2C4 */
@@ -60,11 +54,5 @@
         lines-initial-states = <0x00>;
         gpio-line-names =
             "IOXPD3_IO0_0", "IOXPD3_IO0_1", "IOXPD3_IO0_2", "IOXPD3_IO0_3", "IOXPD3_IO0_4", "IOXPD3_IO0_5", "IOXPD3_IO0_6", "IOXPD3_IO0_7";
-
-        ioxpd_debug_line {
-            gpio-hog;
-            gpios = <6 GPIO_ACTIVE_HIGH>;
-            output-high;
-        };
     };
 };

--- a/recipes-kernel/linux/files/apalis-imx8_multirack-2rack_overlay.dts
+++ b/recipes-kernel/linux/files/apalis-imx8_multirack-2rack_overlay.dts
@@ -39,7 +39,6 @@
         gpio-controller;
         #gpio-cells = <2>;
         label = "pca9674-56246000-1.gpio";
-        /* IO0 and IO1 has to be output high by default */
         lines-initial-states = <0x00>;
         gpio-line-names =
             "IOXPD2_IO0_0", "IOXPD2_IO0_1", "IOXPD2_IO0_2", "IOXPD2_IO0_3", "IOXPD2_IO0_4", "IOXPD2_IO0_5", "IOXPD2_IO0_6", "IOXPD2_IO0_7";
@@ -58,7 +57,6 @@
         gpio-controller;
         #gpio-cells = <2>;
         label = "pca9674-56246000-2.gpio";
-        /* IO0 and IO1 has to be output high by default */
         lines-initial-states = <0x00>;
         gpio-line-names =
             "IOXPD3_IO0_0", "IOXPD3_IO0_1", "IOXPD3_IO0_2", "IOXPD3_IO0_3", "IOXPD3_IO0_4", "IOXPD3_IO0_5", "IOXPD3_IO0_6", "IOXPD3_IO0_7";

--- a/recipes-kernel/linux/files/apalis-imx8_multirack-2rack_overlay.dts
+++ b/recipes-kernel/linux/files/apalis-imx8_multirack-2rack_overlay.dts
@@ -1,0 +1,60 @@
+#include <dt-bindings/gpio/gpio.h>
+
+/dts-v1/;
+/plugin/;
+/ {
+    fragment@101 {
+        target-path = "/";
+        __overlay__ {
+            i2cmux-56246000.i2c {
+                compatible = "i2c-mux-gpio";
+                #address-cells = <1>;
+                #size-cells = <0>;
+                mux-gpios = <&pca9674_1 7 GPIO_ACTIVE_LOW &pca9674_2 7 GPIO_ACTIVE_LOW>;
+                i2c-parent = <&i2c0_lvds0>;
+
+                /* Reg property output to pins, first in the list holds LSB */
+                i2c@1 { /* Expectation: IOXPD at 0x20 pull low */
+                    reg = <1>; /* 0 1 */
+                    #address-cells = <1>;
+                    #size-cells = <0>;
+                };
+                i2c@2 { /* Expectation: IOXPD at 0x21 pull low */
+                    reg = <2>; /* 1 0 */
+                    #address-cells = <1>;
+                    #size-cells = <0>;
+                };
+            };
+        };
+    };
+};
+
+/* RCU's I2C4 */
+&i2c0_lvds0 {
+
+    /* PCA9674 8-bit IO expander on I2C4 */
+    pca9674_1: gpio@20 {
+        compatible = "nxp,pca9674";
+        reg = <0x20>;
+        gpio-controller;
+        #gpio-cells = <2>;
+        label = "pca9674-56246000-1.gpio";
+        /* IO0 and IO1 has to be output high by default */
+        lines-initial-states = <0x00>;
+        gpio-line-names =
+            "IOXPD2_IO0_0", "IOXPD2_IO0_1", "IOXPD2_IO0_2", "IOXPD2_IO0_3", "IOXPD2_IO0_4", "IOXPD2_IO0_5", "IOXPD2_IO0_6", "IOXPD2_IO0_7";
+    };
+    
+    /* PCA9674 8-bit IO expander on I2C4 */
+    pca9674_2: gpio@21 {
+        compatible = "nxp,pca9674";
+        reg = <0x21>;
+        gpio-controller;
+        #gpio-cells = <2>;
+        label = "pca9674-56246000-2.gpio";
+        /* IO0 and IO1 has to be output high by default */
+        lines-initial-states = <0x00>;
+        gpio-line-names =
+            "IOXPD3_IO0_0", "IOXPD3_IO0_1", "IOXPD3_IO0_2", "IOXPD3_IO0_3", "IOXPD3_IO0_4", "IOXPD3_IO0_5", "IOXPD3_IO0_6", "IOXPD3_IO0_7";
+    };
+};

--- a/recipes-kernel/linux/files/apalis-imx8_multirack-2rack_overlay.dts
+++ b/recipes-kernel/linux/files/apalis-imx8_multirack-2rack_overlay.dts
@@ -33,9 +33,9 @@
 &i2c0_lvds0 {
 
     /* PCA9674 8-bit IO expander on I2C4 */
-    pca9674_1: gpio@20 {
+    pca9674_1: gpio@24 {
         compatible = "nxp,pca9674";
-        reg = <0x20>;
+        reg = <0x24>;
         gpio-controller;
         #gpio-cells = <2>;
         label = "pca9674-56246000-1.gpio";
@@ -46,9 +46,9 @@
     };
     
     /* PCA9674 8-bit IO expander on I2C4 */
-    pca9674_2: gpio@21 {
+    pca9674_2: gpio@25 {
         compatible = "nxp,pca9674";
-        reg = <0x21>;
+        reg = <0x25>;
         gpio-controller;
         #gpio-cells = <2>;
         label = "pca9674-56246000-2.gpio";

--- a/recipes-kernel/linux/files/apalis-imx8_multirack-2rack_overlay.dts
+++ b/recipes-kernel/linux/files/apalis-imx8_multirack-2rack_overlay.dts
@@ -14,12 +14,12 @@
                 i2c-parent = <&i2c0_lvds0>;
 
                 /* Reg property output to pins, first in the list holds LSB */
-                i2c@1 { /* Expectation: IOXPD at 0x20 pull low */
+                i2c@1 { /* Expectation: IOXPD at 0x24 pull low */
                     reg = <1>; /* 0 1 */
                     #address-cells = <1>;
                     #size-cells = <0>;
                 };
-                i2c@2 { /* Expectation: IOXPD at 0x21 pull low */
+                i2c@2 { /* Expectation: IOXPD at 0x25 pull low */
                     reg = <2>; /* 1 0 */
                     #address-cells = <1>;
                     #size-cells = <0>;
@@ -43,6 +43,12 @@
         lines-initial-states = <0x00>;
         gpio-line-names =
             "IOXPD2_IO0_0", "IOXPD2_IO0_1", "IOXPD2_IO0_2", "IOXPD2_IO0_3", "IOXPD2_IO0_4", "IOXPD2_IO0_5", "IOXPD2_IO0_6", "IOXPD2_IO0_7";
+
+        ioxpd_debug_line {
+            gpio-hog;
+            gpios = <6 GPIO_ACTIVE_HIGH>;
+            output-high;
+        };
     };
     
     /* PCA9674 8-bit IO expander on I2C4 */
@@ -56,5 +62,11 @@
         lines-initial-states = <0x00>;
         gpio-line-names =
             "IOXPD3_IO0_0", "IOXPD3_IO0_1", "IOXPD3_IO0_2", "IOXPD3_IO0_3", "IOXPD3_IO0_4", "IOXPD3_IO0_5", "IOXPD3_IO0_6", "IOXPD3_IO0_7";
+
+        ioxpd_debug_line {
+            gpio-hog;
+            gpios = <6 GPIO_ACTIVE_HIGH>;
+            output-high;
+        };
     };
 };

--- a/recipes-kernel/linux/files/apalis-imx8_multirack-3rack_overlay.dts
+++ b/recipes-kernel/linux/files/apalis-imx8_multirack-3rack_overlay.dts
@@ -14,17 +14,17 @@
                 i2c-parent = <&i2c0_lvds0>;
 
                 /* Reg property output to pins, first in the list holds LSB */
-                i2c@1 { /* Expectation: IOXPD at 0x20 pull low */
+                i2c@1 { /* Expectation: IOXPD at 0x24 pull low */
                     reg = <1>; /* 0 0 1 */
                     #address-cells = <1>;
                     #size-cells = <0>;
                 };
-                i2c@2 { /* Expectation: IOXPD at 0x21 pull low */
+                i2c@2 { /* Expectation: IOXPD at 0x25 pull low */
                     reg = <2>; /* 0 1 0 */
                     #address-cells = <1>;
                     #size-cells = <0>;
                 };
-                i2c@4 { /* Expectation: IOXPD at 0x23 pull low */
+                i2c@4 { /* Expectation: IOXPD at 0x21 pull low */
                     reg = <4>; /* 1 0 0 */
                     #address-cells = <1>;
                     #size-cells = <0>;
@@ -61,6 +61,12 @@
         lines-initial-states = <0x00>;
         gpio-line-names =
             "IOXPD3_IO0_0", "IOXPD3_IO0_1", "IOXPD3_IO0_2", "IOXPD3_IO0_3", "IOXPD3_IO0_4", "IOXPD3_IO0_5", "IOXPD3_IO0_6", "IOXPD3_IO0_7";
+
+        ioxpd_debug_line {
+            gpio-hog;
+            gpios = <6 GPIO_ACTIVE_HIGH>;
+            output-high;
+        };
     };
     
     /* PCA9674 8-bit IO expander on I2C4 */
@@ -74,5 +80,11 @@
         lines-initial-states = <0x00>;
         gpio-line-names =
             "IOXPD4_IO0_0", "IOXPD4_IO0_1", "IOXPD4_IO0_2", "IOXPD4_IO0_3", "IOXPD4_IO0_4", "IOXPD4_IO0_5", "IOXPD4_IO0_6", "IOXPD4_IO0_7";
+
+        ioxpd_debug_line {
+            gpio-hog;
+            gpios = <6 GPIO_ACTIVE_HIGH>;
+            output-high;
+        };
     };
 };

--- a/recipes-kernel/linux/files/apalis-imx8_multirack-3rack_overlay.dts
+++ b/recipes-kernel/linux/files/apalis-imx8_multirack-3rack_overlay.dts
@@ -38,9 +38,9 @@
 &i2c0_lvds0 {
 
     /* PCA9674 8-bit IO expander on I2C4 */
-    pca9674_1: gpio@20 {
+    pca9674_1: gpio@24 {
         compatible = "nxp,pca9674";
-        reg = <0x20>;
+        reg = <0x24>;
         gpio-controller;
         #gpio-cells = <2>;
         label = "pca9674-56246000-1.gpio";
@@ -51,9 +51,9 @@
     };
     
     /* PCA9674 8-bit IO expander on I2C4 */
-    pca9674_2: gpio@21 {
+    pca9674_2: gpio@25 {
         compatible = "nxp,pca9674";
-        reg = <0x21>;
+        reg = <0x25>;
         gpio-controller;
         #gpio-cells = <2>;
         label = "pca9674-56246000-2.gpio";
@@ -64,9 +64,9 @@
     };
     
     /* PCA9674 8-bit IO expander on I2C4 */
-    pca9674_3: gpio@23 {
+    pca9674_3: gpio@21 {
         compatible = "nxp,pca9674";
-        reg = <0x23>;
+        reg = <0x21>;
         gpio-controller;
         #gpio-cells = <2>;
         label = "pca9674-56246000-3.gpio";

--- a/recipes-kernel/linux/files/apalis-imx8_multirack-3rack_overlay.dts
+++ b/recipes-kernel/linux/files/apalis-imx8_multirack-3rack_overlay.dts
@@ -1,0 +1,78 @@
+#include <dt-bindings/gpio/gpio.h>
+
+/dts-v1/;
+/plugin/;
+/ {
+    fragment@100 {
+        target-path = "/";
+        __overlay__ {
+            i2cmux-56246000.i2c {
+                compatible = "i2c-mux-gpio";
+                #address-cells = <1>;
+                #size-cells = <0>;
+                mux-gpios = <&pca9674_1 7 GPIO_ACTIVE_LOW &pca9674_2 7 GPIO_ACTIVE_LOW &pca9674_3 7 GPIO_ACTIVE_LOW>;
+                i2c-parent = <&i2c0_lvds0>;
+
+                /* Reg property output to pins, first in the list holds LSB */
+                i2c@1 { /* Expectation: IOXPD at 0x20 pull low */
+                    reg = <1>; /* 0 0 1 */
+                    #address-cells = <1>;
+                    #size-cells = <0>;
+                };
+                i2c@2 { /* Expectation: IOXPD at 0x21 pull low */
+                    reg = <2>; /* 0 1 0 */
+                    #address-cells = <1>;
+                    #size-cells = <0>;
+                };
+                i2c@4 { /* Expectation: IOXPD at 0x23 pull low */
+                    reg = <4>; /* 1 0 0 */
+                    #address-cells = <1>;
+                    #size-cells = <0>;
+                };
+            };
+        };
+    };
+};
+
+/* RCU's I2C4 */
+&i2c0_lvds0 {
+
+    /* PCA9674 8-bit IO expander on I2C4 */
+    pca9674_1: gpio@20 {
+        compatible = "nxp,pca9674";
+        reg = <0x20>;
+        gpio-controller;
+        #gpio-cells = <2>;
+        label = "pca9674-56246000-1.gpio";
+        /* IO0 and IO1 has to be output high by default */
+        lines-initial-states = <0x00>;
+        gpio-line-names =
+            "IOXPD2_IO0_0", "IOXPD2_IO0_1", "IOXPD2_IO0_2", "IOXPD2_IO0_3", "IOXPD2_IO0_4", "IOXPD2_IO0_5", "IOXPD2_IO0_6", "IOXPD2_IO0_7";
+    };
+    
+    /* PCA9674 8-bit IO expander on I2C4 */
+    pca9674_2: gpio@21 {
+        compatible = "nxp,pca9674";
+        reg = <0x21>;
+        gpio-controller;
+        #gpio-cells = <2>;
+        label = "pca9674-56246000-2.gpio";
+        /* IO0 and IO1 has to be output high by default */
+        lines-initial-states = <0x00>;
+        gpio-line-names =
+            "IOXPD3_IO0_0", "IOXPD3_IO0_1", "IOXPD3_IO0_2", "IOXPD3_IO0_3", "IOXPD3_IO0_4", "IOXPD3_IO0_5", "IOXPD3_IO0_6", "IOXPD3_IO0_7";
+    };
+    
+    /* PCA9674 8-bit IO expander on I2C4 */
+    pca9674_3: gpio@23 {
+        compatible = "nxp,pca9674";
+        reg = <0x23>;
+        gpio-controller;
+        #gpio-cells = <2>;
+        label = "pca9674-56246000-3.gpio";
+        /* IO0 and IO1 has to be output high by default */
+        lines-initial-states = <0x00>;
+        gpio-line-names =
+            "IOXPD4_IO0_0", "IOXPD4_IO0_1", "IOXPD4_IO0_2", "IOXPD4_IO0_3", "IOXPD4_IO0_4", "IOXPD4_IO0_5", "IOXPD4_IO0_6", "IOXPD4_IO0_7";
+    };
+};

--- a/recipes-kernel/linux/files/apalis-imx8_multirack-3rack_overlay.dts
+++ b/recipes-kernel/linux/files/apalis-imx8_multirack-3rack_overlay.dts
@@ -44,10 +44,15 @@
         gpio-controller;
         #gpio-cells = <2>;
         label = "pca9674-56246000-1.gpio";
-        /* IO0 and IO1 has to be output high by default */
         lines-initial-states = <0x00>;
         gpio-line-names =
             "IOXPD2_IO0_0", "IOXPD2_IO0_1", "IOXPD2_IO0_2", "IOXPD2_IO0_3", "IOXPD2_IO0_4", "IOXPD2_IO0_5", "IOXPD2_IO0_6", "IOXPD2_IO0_7";
+
+        ioxpd_debug_line {
+            gpio-hog;
+            gpios = <6 GPIO_ACTIVE_HIGH>;
+            output-high;
+        };
     };
     
     /* PCA9674 8-bit IO expander on I2C4 */
@@ -57,7 +62,6 @@
         gpio-controller;
         #gpio-cells = <2>;
         label = "pca9674-56246000-2.gpio";
-        /* IO0 and IO1 has to be output high by default */
         lines-initial-states = <0x00>;
         gpio-line-names =
             "IOXPD3_IO0_0", "IOXPD3_IO0_1", "IOXPD3_IO0_2", "IOXPD3_IO0_3", "IOXPD3_IO0_4", "IOXPD3_IO0_5", "IOXPD3_IO0_6", "IOXPD3_IO0_7";
@@ -76,7 +80,6 @@
         gpio-controller;
         #gpio-cells = <2>;
         label = "pca9674-56246000-3.gpio";
-        /* IO0 and IO1 has to be output high by default */
         lines-initial-states = <0x00>;
         gpio-line-names =
             "IOXPD4_IO0_0", "IOXPD4_IO0_1", "IOXPD4_IO0_2", "IOXPD4_IO0_3", "IOXPD4_IO0_4", "IOXPD4_IO0_5", "IOXPD4_IO0_6", "IOXPD4_IO0_7";

--- a/recipes-kernel/linux/files/apalis-imx8_multirack-3rack_overlay.dts
+++ b/recipes-kernel/linux/files/apalis-imx8_multirack-3rack_overlay.dts
@@ -47,12 +47,6 @@
         lines-initial-states = <0x00>;
         gpio-line-names =
             "IOXPD2_IO0_0", "IOXPD2_IO0_1", "IOXPD2_IO0_2", "IOXPD2_IO0_3", "IOXPD2_IO0_4", "IOXPD2_IO0_5", "IOXPD2_IO0_6", "IOXPD2_IO0_7";
-
-        ioxpd_debug_line {
-            gpio-hog;
-            gpios = <6 GPIO_ACTIVE_HIGH>;
-            output-high;
-        };
     };
     
     /* PCA9674 8-bit IO expander on I2C4 */
@@ -65,12 +59,6 @@
         lines-initial-states = <0x00>;
         gpio-line-names =
             "IOXPD3_IO0_0", "IOXPD3_IO0_1", "IOXPD3_IO0_2", "IOXPD3_IO0_3", "IOXPD3_IO0_4", "IOXPD3_IO0_5", "IOXPD3_IO0_6", "IOXPD3_IO0_7";
-
-        ioxpd_debug_line {
-            gpio-hog;
-            gpios = <6 GPIO_ACTIVE_HIGH>;
-            output-high;
-        };
     };
     
     /* PCA9674 8-bit IO expander on I2C4 */
@@ -83,11 +71,5 @@
         lines-initial-states = <0x00>;
         gpio-line-names =
             "IOXPD4_IO0_0", "IOXPD4_IO0_1", "IOXPD4_IO0_2", "IOXPD4_IO0_3", "IOXPD4_IO0_4", "IOXPD4_IO0_5", "IOXPD4_IO0_6", "IOXPD4_IO0_7";
-
-        ioxpd_debug_line {
-            gpio-hog;
-            gpios = <6 GPIO_ACTIVE_HIGH>;
-            output-high;
-        };
     };
 };


### PR DESCRIPTION
PR to address [US 2896515](https://dev.azure.com/ni/DevCentral/_workitems/edit/2896515).

I/O expander locations currently set by HW at I2C4, 24h, 25h and 21h for rack 1, 2 and 3 respectively. 

Testing was done on prototype connected to PEP I2C, so we'll need to test this again once the real multirack setup is available. 