### PR TITLE
Hog IO6 of each IO expander in multirack configuration to output high

### DIFF
--- a/recipes-kernel/linux/files/apalis-imx8_multirack-2rack_overlay.dts
+++ b/recipes-kernel/linux/files/apalis-imx8_multirack-2rack_overlay.dts
@@ -42,6 +42,12 @@
         lines-initial-states = <0x00>;
         gpio-line-names =
             "IOXPD2_IO0_0", "IOXPD2_IO0_1", "IOXPD2_IO0_2", "IOXPD2_IO0_3", "IOXPD2_IO0_4", "IOXPD2_IO0_5", "IOXPD2_IO0_6", "IOXPD2_IO0_7";
+
+        ioxpd_debug_line {
+            gpio-hog;
+            gpios = <6 GPIO_ACTIVE_HIGH>;
+            output-high;
+        };
     };
     
     /* PCA9674 8-bit IO expander on I2C4 */
@@ -54,5 +60,11 @@
         lines-initial-states = <0x00>;
         gpio-line-names =
             "IOXPD3_IO0_0", "IOXPD3_IO0_1", "IOXPD3_IO0_2", "IOXPD3_IO0_3", "IOXPD3_IO0_4", "IOXPD3_IO0_5", "IOXPD3_IO0_6", "IOXPD3_IO0_7";
+
+        ioxpd_debug_line {
+            gpio-hog;
+            gpios = <6 GPIO_ACTIVE_HIGH>;
+            output-high;
+        };
     };
 };

--- a/recipes-kernel/linux/files/apalis-imx8_multirack-3rack_overlay.dts
+++ b/recipes-kernel/linux/files/apalis-imx8_multirack-3rack_overlay.dts
@@ -47,6 +47,12 @@
         lines-initial-states = <0x00>;
         gpio-line-names =
             "IOXPD2_IO0_0", "IOXPD2_IO0_1", "IOXPD2_IO0_2", "IOXPD2_IO0_3", "IOXPD2_IO0_4", "IOXPD2_IO0_5", "IOXPD2_IO0_6", "IOXPD2_IO0_7";
+
+        ioxpd_debug_line {
+            gpio-hog;
+            gpios = <6 GPIO_ACTIVE_HIGH>;
+            output-high;
+        };
     };
     
     /* PCA9674 8-bit IO expander on I2C4 */
@@ -59,6 +65,12 @@
         lines-initial-states = <0x00>;
         gpio-line-names =
             "IOXPD3_IO0_0", "IOXPD3_IO0_1", "IOXPD3_IO0_2", "IOXPD3_IO0_3", "IOXPD3_IO0_4", "IOXPD3_IO0_5", "IOXPD3_IO0_6", "IOXPD3_IO0_7";
+
+        ioxpd_debug_line {
+            gpio-hog;
+            gpios = <6 GPIO_ACTIVE_HIGH>;
+            output-high;
+        };
     };
     
     /* PCA9674 8-bit IO expander on I2C4 */
@@ -71,5 +83,11 @@
         lines-initial-states = <0x00>;
         gpio-line-names =
             "IOXPD4_IO0_0", "IOXPD4_IO0_1", "IOXPD4_IO0_2", "IOXPD4_IO0_3", "IOXPD4_IO0_4", "IOXPD4_IO0_5", "IOXPD4_IO0_6", "IOXPD4_IO0_7";
+
+        ioxpd_debug_line {
+            gpio-hog;
+            gpios = <6 GPIO_ACTIVE_HIGH>;
+            output-high;
+        };
     };
 };


### PR DESCRIPTION
Continuation of https://github.com/ni/meta-ateccgen2/pull/142. After discussion with HW, we will only drive IO6 high and do no additional work for multirack board debug features.