### PR TITLE
Retain overlay configuration after Mender update

### DIFF
--- a/recipes-mender/rcu-state-scripts/files/retain-overlay-configuration
+++ b/recipes-mender/rcu-state-scripts/files/retain-overlay-configuration
@@ -1,0 +1,39 @@
+#!/bin/sh
+#
+# Retain /boot/overlays.txt from the current root
+#
+
+echo "$(mender show-artifact): Running $(basename "$0")" >&2
+
+# Check current rootfs partition
+current=$(mount | awk '$3 == "/" {print $1}')
+
+# Deduce target rootfs partition based on current rootfs partition number
+if [ $current = "/dev/mmcblk0p2" ]; then
+    newroot=/dev/mmcblk0p3
+elif [ $current = "/dev/mmcblk0p3" ]; then
+    newroot=/dev/mmcblk0p2
+else
+    echo "Unexpected current root: $current" >&2
+    exit 1
+fi
+
+mount $newroot /mnt
+
+if [ $? -ne 0 ]; then
+    echo "Failed to mount $newroot" >&2
+    exit 1
+fi
+
+sleep 2
+
+if [ -d /mnt/boot ]; then
+    cp /boot/overlays.txt /mnt/boot/overlays.txt
+    echo "Copied overlays.txt to new root partition" >&2
+else
+    echo "Failed to find /boot on new root partition" >&2
+    umount $newroot
+    exit 1
+fi
+
+umount $newroot

--- a/recipes-mender/rcu-state-scripts/rcu-state-scripts_1.0.bb
+++ b/recipes-mender/rcu-state-scripts/rcu-state-scripts_1.0.bb
@@ -8,6 +8,7 @@ SRC_URI = " \
     file://retain-ssh-service-status \
     file://retain-ssl-key-pair \
     file://retain-dbus-machine-id \
+    file://retain-overlay-configuration \
 "
 
 inherit mender-state-scripts
@@ -17,4 +18,5 @@ do_compile() {
     cp ${WORKDIR}/retain-ssh-service-status ${MENDER_STATE_SCRIPTS_DIR}/ArtifactInstall_Enter_01
     cp ${WORKDIR}/retain-ssl-key-pair ${MENDER_STATE_SCRIPTS_DIR}/ArtifactInstall_Enter_02
     cp ${WORKDIR}/retain-dbus-machine-id ${MENDER_STATE_SCRIPTS_DIR}/ArtifactInstall_Enter_03
+    cp ${WORKDIR}/retain-overlay-configuration ${MENDER_STATE_SCRIPTS_DIR}/ArtifactInstall_Enter_04
 }


### PR DESCRIPTION
Some investigation show that new RCUs after a TEZI update run an updated bootloader together with new u-boot environment variables which cause RCU to load overlays based on overlays available in /boot instead of /uboot. This means that it will be possible for Mender updates to overwrite existing overlay configurations present on the RCU. 

This PR adds a state script which copies over overlay.txt from the old rootfs to new rootfs after a Mender update. 