### PR TITLE
Add device tree overlay for multirack-1rack (#147)

### DIFF
--- a/recipes-kernel/linux/device-tree-overlays_git.bbappend
+++ b/recipes-kernel/linux/device-tree-overlays_git.bbappend
@@ -3,12 +3,14 @@ TEZI_EXTERNAL_KERNEL_DEVICETREE_BOOT:apalis-imx8 = " apalis-imx8_hdmi_overlay.dt
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
 SRC_URI += " \
+    file://apalis-imx8_multirack-1rack_overlay.dts \
     file://apalis-imx8_multirack-2rack_overlay.dts \
     file://apalis-imx8_multirack-3rack_overlay.dts \
 "
 
 do_collect_overlays:prepend() {
     # Copy custom overlays into Toradex workdir defined in toradex-devicetree.bbclass
+    cp ${WORKDIR}/apalis-imx8_multirack-1rack_overlay.dts ${S}
     cp ${WORKDIR}/apalis-imx8_multirack-2rack_overlay.dts ${S}
     cp ${WORKDIR}/apalis-imx8_multirack-3rack_overlay.dts ${S}
 }

--- a/recipes-kernel/linux/files/apalis-imx8_multirack-1rack_overlay.dts
+++ b/recipes-kernel/linux/files/apalis-imx8_multirack-1rack_overlay.dts
@@ -1,0 +1,47 @@
+#include <dt-bindings/gpio/gpio.h>
+
+/dts-v1/;
+/plugin/;
+/ {
+    fragment@102 {
+        target-path = "/";
+        __overlay__ {
+            i2cmux-56246000.i2c {
+                compatible = "i2c-mux-gpio";
+                #address-cells = <1>;
+                #size-cells = <0>;
+                mux-gpios = <&pca9674_1 7 GPIO_ACTIVE_LOW>;
+                i2c-parent = <&i2c0_lvds0>;
+
+                /* Reg property output to pins, first in the list holds LSB */
+                i2c@1 { /* Expectation: IOXPD at 0x24 pull low */
+                    reg = <1>;
+                    #address-cells = <1>;
+                    #size-cells = <0>;
+                };
+            };
+        };
+    };
+};
+
+/* RCU's I2C4 */
+&i2c0_lvds0 {
+
+    /* PCA9674 8-bit IO expander on I2C4 */
+    pca9674_1: gpio@24 {
+        compatible = "nxp,pca9674";
+        reg = <0x24>;
+        gpio-controller;
+        #gpio-cells = <2>;
+        label = "pca9674-56246000-1.gpio";
+        lines-initial-states = <0x00>;
+        gpio-line-names =
+            "IOXPD2_IO0_0", "IOXPD2_IO0_1", "IOXPD2_IO0_2", "IOXPD2_IO0_3", "IOXPD2_IO0_4", "IOXPD2_IO0_5", "IOXPD2_IO0_6", "IOXPD2_IO0_7";
+
+        ioxpd_debug_line {
+            gpio-hog;
+            gpios = <6 GPIO_ACTIVE_HIGH>;
+            output-high;
+        };
+    };
+};


### PR DESCRIPTION
## Justification
Cherry-pick from the main branch - https://github.com/ni/meta-ateccgen2/pull/147
Add device tree overlay to support multirack-1rack
AzDO: [2972992](https://ni.visualstudio.com/DevCentral/_workitems/edit/2972992)

## Testing
Verified in "Gamora with mrd board + fan panel without fan" and "Rack with mrd board + fan panel + fans in STS lab". Refer to [2972992](https://ni.visualstudio.com/DevCentral/_workitems/edit/2972992)